### PR TITLE
add lifetimes to cursors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "jammdb"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jammdb"
 description = "An embedded single-file database for Rust"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["PJ Tatlow <pjtatlow@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use crate::bucket::Bucket;
 use crate::data::Data;
 use crate::node::{Node, NodeData, NodeID};
@@ -132,18 +134,20 @@ impl PageNode {
 /// # Ok(())
 /// # }
 /// ```
-pub struct Cursor {
+pub struct Cursor<'a> {
 	bucket: Ptr<Bucket>,
 	stack: Vec<Elem>,
 	next_called: bool,
+	_phantom: PhantomData<&'a ()>,
 }
 
-impl Cursor {
-	pub(crate) fn new(b: Ptr<Bucket>) -> Cursor {
+impl<'a> Cursor<'a> {
+	pub(crate) fn new(b: Ptr<Bucket>) -> Cursor<'a> {
 		Cursor {
 			bucket: b,
 			stack: vec![],
 			next_called: false,
+			_phantom: PhantomData {},
 		}
 	}
 
@@ -224,7 +228,7 @@ impl Cursor {
 	}
 }
 
-impl Iterator for Cursor {
+impl<'a> Iterator for Cursor<'a> {
 	type Item = Data;
 
 	fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
This PR adds lifetimes to the `Cursor` struct which makes it so you can't use it unsafely after the transaction is dropped.

Closes #3 