### PR TITLE
convert tabs to spaces and add more iterators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "jammdb"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "fs2",
  "memmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jammdb"
 description = "An embedded single-file database for Rust"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["PJ Tatlow <pjtatlow@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 
-use crate::cursor::{Cursor, PageNode, PageNodeID};
+use crate::cursor::{Buckets, Cursor, KVPairs, PageNode, PageNodeID};
 use crate::data::{BucketData, Data, KVPair, Ref};
 use crate::errors::{Error, Result};
 use crate::node::{Branch, Node, NodeData, NodeID};
@@ -61,778 +61,795 @@ use crate::transaction::TransactionInner;
 /// # }
 /// ```
 pub struct Bucket {
-	inner: RefCell<BucketInner>,
+    inner: RefCell<BucketInner>,
 }
 
 impl Bucket {
-	pub(crate) fn root(tx: Ptr<TransactionInner>) -> Bucket {
-		let meta = tx.meta.root;
-		Bucket::new(BucketInner {
-			tx,
-			meta,
-			root: PageNodeID::Page(meta.root_page),
-			dirty: false,
-			buckets: HashMap::new(),
-			nodes: Vec::new(),
-			page_node_ids: HashMap::new(),
-			page_parents: HashMap::new(),
-		})
-	}
+    pub(crate) fn root(tx: Ptr<TransactionInner>) -> Bucket {
+        let meta = tx.meta.root;
+        Bucket::new(BucketInner {
+            tx,
+            meta,
+            root: PageNodeID::Page(meta.root_page),
+            dirty: false,
+            buckets: HashMap::new(),
+            nodes: Vec::new(),
+            page_node_ids: HashMap::new(),
+            page_parents: HashMap::new(),
+        })
+    }
 
-	pub(crate) fn new(inner: BucketInner) -> Bucket {
-		Bucket {
-			inner: RefCell::new(inner),
-		}
-	}
+    pub(crate) fn new(inner: BucketInner) -> Bucket {
+        Bucket {
+            inner: RefCell::new(inner),
+        }
+    }
 
-	/// Adds to or replaces key / value data in the bucket.
-	/// Returns an error if the key currently exists but is a bucket instead of a key / value pair.
-	///
-	/// # Examples
-	///
-	/// ```no_run
-	/// use jammdb::{DB};
-	/// # use jammdb::Error;
-	///
-	/// # fn main() -> Result<(), Error> {
-	/// let db = DB::open("my.db")?;
-	/// let mut tx = db.tx(true)?;
-	///
-	/// // create a root-level bucket
-	/// let bucket = tx.create_bucket("my-bucket")?;
-	///
-	/// // insert data
-	/// bucket.put("123", "456")?;
-	///
-	/// // update data
-	/// bucket.put("123", "789")?;
-	///
-	/// bucket.create_bucket("nested-bucket")?;
-	///
-	/// assert!(bucket.put("nested-bucket", "data").is_err());
-	///
-	/// # Ok(())
-	/// # }
-	/// ```
-	pub fn put<T: AsRef<[u8]>, S: AsRef<[u8]>>(
-		&self,
-		key: T,
-		value: S,
-	) -> Result<Option<Ref<KVPair>>> {
-		Ok(self.inner.borrow_mut().put(key, value)?.map(Ref::new))
-	}
+    /// Adds to or replaces key / value data in the bucket.
+    /// Returns an error if the key currently exists but is a bucket instead of a key / value pair.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use jammdb::{DB};
+    /// # use jammdb::Error;
+    ///
+    /// # fn main() -> Result<(), Error> {
+    /// let db = DB::open("my.db")?;
+    /// let mut tx = db.tx(true)?;
+    ///
+    /// // create a root-level bucket
+    /// let bucket = tx.create_bucket("my-bucket")?;
+    ///
+    /// // insert data
+    /// bucket.put("123", "456")?;
+    ///
+    /// // update data
+    /// bucket.put("123", "789")?;
+    ///
+    /// bucket.create_bucket("nested-bucket")?;
+    ///
+    /// assert!(bucket.put("nested-bucket", "data").is_err());
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn put<T: AsRef<[u8]>, S: AsRef<[u8]>>(
+        &self,
+        key: T,
+        value: S,
+    ) -> Result<Option<Ref<KVPair>>> {
+        Ok(self.inner.borrow_mut().put(key, value)?.map(Ref::new))
+    }
 
-	/// Get a cursor to iterate over the bucket.
-	///
-	///
-	/// # Examples
-	///
-	/// ```no_run
-	/// use jammdb::{DB, Data};
-	/// # use jammdb::Error;
-	///
-	/// # fn main() -> Result<(), Error> {
-	/// let db = DB::open("my.db")?;
-	/// let mut tx = db.tx(false)?;
-	///
-	/// let bucket = tx.get_bucket("my-bucket")?;
-	///
-	/// for data in bucket.cursor() {
-	///     match &*data {
-	///         Data::Bucket(b) => println!("found a bucket with the name {:?}", b.name()),
-	///         Data::KeyValue(kv) => println!("found a kv pair {:?} {:?}", kv.key(), kv.value()),
-	///     }
-	/// }
-	///
-	/// # Ok(())
-	/// # }
-	/// ```
-	pub fn cursor(&self) -> Cursor {
-		Cursor::new(Ptr::new(&self.inner.borrow()))
-	}
+    /// Get a cursor to iterate over the bucket.
+    ///
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use jammdb::{DB, Data};
+    /// # use jammdb::Error;
+    ///
+    /// # fn main() -> Result<(), Error> {
+    /// let db = DB::open("my.db")?;
+    /// let mut tx = db.tx(false)?;
+    ///
+    /// let bucket = tx.get_bucket("my-bucket")?;
+    ///
+    /// for data in bucket.cursor() {
+    ///     match &*data {
+    ///         Data::Bucket(b) => println!("found a bucket with the name {:?}", b.name()),
+    ///         Data::KeyValue(kv) => println!("found a kv pair {:?} {:?}", kv.key(), kv.value()),
+    ///     }
+    /// }
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn cursor(&self) -> Cursor {
+        Cursor::new(Ptr::new(&self.inner.borrow()))
+    }
 
-	/// Gets an already created bucket.
-	///
-	/// Returns an error if
-	/// 1. the given key does not exist
-	/// 2. the key is for key / value data, not a bucket
-	///
-	/// # Examples
-	///
-	/// ```no_run
-	/// use jammdb::{DB};
-	/// # use jammdb::Error;
-	///
-	/// # fn main() -> Result<(), Error> {
-	/// let db = DB::open("my.db")?;
-	/// let mut tx = db.tx(false)?;
-	///
-	/// // get a root-level bucket
-	/// let bucket = tx.get_bucket("my-bucket")?;
-	///
-	/// // get nested bucket
-	/// let mut sub_bucket = bucket.get_bucket("nested-bucket")?;
-	///
-	/// // get nested bucket
-	/// let sub_sub_bucket = sub_bucket.get_bucket("double-nested-bucket")?;
-	///
-	/// # Ok(())
-	/// # }
-	/// ```
-	pub fn get_bucket<T: AsRef<[u8]>>(&self, name: T) -> Result<BucketRef> {
-		let mut inner = self.inner.borrow_mut();
-		let r = inner.bucket_getter(name.as_ref(), false, false)?;
-		Ok(BucketRef::new(unsafe { &*r.bucket }))
-	}
+    /// Gets an already created bucket.
+    ///
+    /// Returns an error if
+    /// 1. the given key does not exist
+    /// 2. the key is for key / value data, not a bucket
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use jammdb::{DB};
+    /// # use jammdb::Error;
+    ///
+    /// # fn main() -> Result<(), Error> {
+    /// let db = DB::open("my.db")?;
+    /// let mut tx = db.tx(false)?;
+    ///
+    /// // get a root-level bucket
+    /// let bucket = tx.get_bucket("my-bucket")?;
+    ///
+    /// // get nested bucket
+    /// let mut sub_bucket = bucket.get_bucket("nested-bucket")?;
+    ///
+    /// // get nested bucket
+    /// let sub_sub_bucket = sub_bucket.get_bucket("double-nested-bucket")?;
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn get_bucket<T: AsRef<[u8]>>(&self, name: T) -> Result<BucketRef> {
+        let mut inner = self.inner.borrow_mut();
+        let r = inner.bucket_getter(name.as_ref(), false, false)?;
+        Ok(BucketRef::new(unsafe { &*r.bucket }))
+    }
 
-	/// Deletes a key / value pair from the bucket
-	///
-	/// # Examples
-	///
-	/// ```no_run
-	/// use jammdb::{DB};
-	/// # use jammdb::Error;
-	///
-	/// # fn main() -> Result<(), Error> {
-	/// let db = DB::open("my.db")?;
-	/// let mut tx = db.tx(false)?;
-	///
-	/// let bucket = tx.get_bucket("my-bucket")?;
-	/// // check if data is there
-	/// assert!(bucket.get_kv("some-key").is_some());
-	/// // delete the key / value pair
-	/// bucket.delete("some-key")?;
-	/// // data should no longer exist
-	/// assert!(bucket.get_kv("some-key").is_none());
-	///
-	/// # Ok(())
-	/// # }
-	/// ```
-	pub fn delete<T: AsRef<[u8]>>(&self, key: T) -> Result<Ref<KVPair>> {
-		Ok(Ref::new(self.inner.borrow_mut().delete(key)?))
-	}
+    /// Deletes a key / value pair from the bucket
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use jammdb::{DB};
+    /// # use jammdb::Error;
+    ///
+    /// # fn main() -> Result<(), Error> {
+    /// let db = DB::open("my.db")?;
+    /// let mut tx = db.tx(false)?;
+    ///
+    /// let bucket = tx.get_bucket("my-bucket")?;
+    /// // check if data is there
+    /// assert!(bucket.get_kv("some-key").is_some());
+    /// // delete the key / value pair
+    /// bucket.delete("some-key")?;
+    /// // data should no longer exist
+    /// assert!(bucket.get_kv("some-key").is_none());
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn delete<T: AsRef<[u8]>>(&self, key: T) -> Result<Ref<KVPair>> {
+        Ok(Ref::new(self.inner.borrow_mut().delete(key)?))
+    }
 
-	/// Creates a new bucket.
-	///
-	/// Returns an error if
-	/// 1. the given key already exists
-	/// 2. It is in a read-only transaction
-	///
-	/// # Examples
-	///
-	/// ```no_run
-	/// use jammdb::{DB};
-	/// # use jammdb::Error;
-	///
-	/// # fn main() -> Result<(), Error> {
-	/// let db = DB::open("my.db")?;
-	/// let mut tx = db.tx(true)?;
-	///
-	/// // create a root-level bucket
-	/// let bucket = tx.create_bucket("my-bucket")?;
-	///
-	/// // create nested bucket
-	/// let mut sub_bucket = bucket.create_bucket("nested-bucket")?;
-	///
-	/// // create nested bucket
-	/// let mut sub_sub_bucket = sub_bucket.create_bucket("double-nested-bucket")?;
-	///
-	/// # Ok(())
-	/// # }
-	/// ```
-	pub fn create_bucket<T: AsRef<[u8]>>(&self, name: T) -> Result<BucketRef> {
-		let mut inner = self.inner.borrow_mut();
-		let r = inner.create_bucket(name)?;
-		Ok(BucketRef::new(unsafe { &*r.bucket }))
-	}
+    /// Creates a new bucket.
+    ///
+    /// Returns an error if
+    /// 1. the given key already exists
+    /// 2. It is in a read-only transaction
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use jammdb::{DB};
+    /// # use jammdb::Error;
+    ///
+    /// # fn main() -> Result<(), Error> {
+    /// let db = DB::open("my.db")?;
+    /// let mut tx = db.tx(true)?;
+    ///
+    /// // create a root-level bucket
+    /// let bucket = tx.create_bucket("my-bucket")?;
+    ///
+    /// // create nested bucket
+    /// let mut sub_bucket = bucket.create_bucket("nested-bucket")?;
+    ///
+    /// // create nested bucket
+    /// let mut sub_sub_bucket = sub_bucket.create_bucket("double-nested-bucket")?;
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn create_bucket<T: AsRef<[u8]>>(&self, name: T) -> Result<BucketRef> {
+        let mut inner = self.inner.borrow_mut();
+        let r = inner.create_bucket(name)?;
+        Ok(BucketRef::new(unsafe { &*r.bucket }))
+    }
 
-	/// Creates a new bucket if it doesn't exist
-	///
-	/// Returns an error if
-	/// 1. It is in a read-only transaction
-	///
-	/// # Examples
-	///
-	/// ```no_run
-	/// use jammdb::{DB};
-	/// # use jammdb::Error;
-	///
-	/// # fn main() -> Result<(), Error> {
-	/// let db = DB::open("my.db")?;
-	/// {
-	///     let mut tx = db.tx(true)?;
-	///     // create a root-level bucket
-	///     let bucket = tx.get_or_create_bucket("my-bucket")?;
-	///     tx.commit()?;
-	/// }
-	/// {
-	///     let mut tx = db.tx(true)?;
-	///     // get the existing a root-level bucket
-	///     let bucket = tx.get_or_create_bucket("my-bucket")?;
-	/// }
-	///
-	/// # Ok(())
-	/// # }
-	/// ```
-	pub fn get_or_create_bucket<T: AsRef<[u8]>>(&self, name: T) -> Result<BucketRef> {
-		let mut inner = self.inner.borrow_mut();
-		let r = inner.get_or_create_bucket(name)?;
-		Ok(BucketRef::new(unsafe { &*r.bucket }))
-	}
+    /// Creates a new bucket if it doesn't exist
+    ///
+    /// Returns an error if
+    /// 1. It is in a read-only transaction
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use jammdb::{DB};
+    /// # use jammdb::Error;
+    ///
+    /// # fn main() -> Result<(), Error> {
+    /// let db = DB::open("my.db")?;
+    /// {
+    ///     let mut tx = db.tx(true)?;
+    ///     // create a root-level bucket
+    ///     let bucket = tx.get_or_create_bucket("my-bucket")?;
+    ///     tx.commit()?;
+    /// }
+    /// {
+    ///     let mut tx = db.tx(true)?;
+    ///     // get the existing a root-level bucket
+    ///     let bucket = tx.get_or_create_bucket("my-bucket")?;
+    /// }
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn get_or_create_bucket<T: AsRef<[u8]>>(&self, name: T) -> Result<BucketRef> {
+        let mut inner = self.inner.borrow_mut();
+        let r = inner.get_or_create_bucket(name)?;
+        Ok(BucketRef::new(unsafe { &*r.bucket }))
+    }
 
-	/// Deletes an bucket.
-	///
-	/// Returns an error if
-	/// 1. the given key does not exist
-	/// 2. the key is for key / value data, not a bucket
-	/// 3. It is in a read-only transaction
-	///
-	/// # Examples
-	///
-	/// ```no_run
-	/// use jammdb::{DB};
-	/// # use jammdb::Error;
-	///
-	/// # fn main() -> Result<(), Error> {
-	/// let db = DB::open("my.db")?;
-	/// let mut tx = db.tx(true)?;
-	///
-	/// // get a root-level bucket
-	/// let bucket = tx.get_bucket("my-bucket")?;
-	///
-	/// // delete nested bucket
-	/// bucket.delete_bucket("nested-bucket")?;
-	///
-	/// # Ok(())
-	/// # }
-	/// ```
-	pub fn delete_bucket<T: AsRef<[u8]>>(&self, name: T) -> Result<()> {
-		self.inner.borrow_mut().delete_bucket(name)
-	}
+    /// Deletes an bucket.
+    ///
+    /// Returns an error if
+    /// 1. the given key does not exist
+    /// 2. the key is for key / value data, not a bucket
+    /// 3. It is in a read-only transaction
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use jammdb::{DB};
+    /// # use jammdb::Error;
+    ///
+    /// # fn main() -> Result<(), Error> {
+    /// let db = DB::open("my.db")?;
+    /// let mut tx = db.tx(true)?;
+    ///
+    /// // get a root-level bucket
+    /// let bucket = tx.get_bucket("my-bucket")?;
+    ///
+    /// // delete nested bucket
+    /// bucket.delete_bucket("nested-bucket")?;
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn delete_bucket<T: AsRef<[u8]>>(&self, name: T) -> Result<()> {
+        self.inner.borrow_mut().delete_bucket(name)
+    }
 
-	/// Returns the next integer for the bucket.
-	/// The integer is automatically incremented each time a new key is added to the bucket.
-	/// You can it as a unique key for the bucket, since it will increment each time you add something new.
-	/// It will not increment if you [`put`](#method.put) a key that already exists
-	///
-	/// # Examples
-	///
-	/// ```no_run
-	/// use jammdb::{DB};
-	/// # use jammdb::Error;
-	///
-	/// # fn main() -> Result<(), Error> {
-	/// let db = DB::open("my.db")?;
-	/// let mut tx = db.tx(true)?;
-	///
-	/// // create a root-level bucket
-	/// let bucket = tx.create_bucket("my-bucket")?;
-	/// // starts at 0
-	/// assert_eq!(bucket.next_int(), 0);
-	///
-	/// let next_int = bucket.next_int();
-	/// bucket.put(next_int.to_be_bytes(), [0]);
-	/// // auto-incremented after inserting a key / value pair
-	/// assert_eq!(bucket.next_int(), 1);
-	///
-	/// bucket.put(0_u64.to_be_bytes(), [0, 0]);
-	/// // not incremented after updating a key / value pair
-	/// assert_eq!(bucket.next_int(), 1);
-	///
-	/// bucket.create_bucket("nested-bucket")?;
-	/// // auto-incremented after creating a nested bucket
-	/// assert_eq!(bucket.next_int(), 2);
-	///
-	/// # Ok(())
-	/// # }
-	/// ```
-	pub fn next_int(&self) -> u64 {
-		self.inner.borrow().meta.next_int
-	}
+    /// Returns the next integer for the bucket.
+    /// The integer is automatically incremented each time a new key is added to the bucket.
+    /// You can it as a unique key for the bucket, since it will increment each time you add something new.
+    /// It will not increment if you [`put`](#method.put) a key that already exists
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use jammdb::{DB};
+    /// # use jammdb::Error;
+    ///
+    /// # fn main() -> Result<(), Error> {
+    /// let db = DB::open("my.db")?;
+    /// let mut tx = db.tx(true)?;
+    ///
+    /// // create a root-level bucket
+    /// let bucket = tx.create_bucket("my-bucket")?;
+    /// // starts at 0
+    /// assert_eq!(bucket.next_int(), 0);
+    ///
+    /// let next_int = bucket.next_int();
+    /// bucket.put(next_int.to_be_bytes(), [0]);
+    /// // auto-incremented after inserting a key / value pair
+    /// assert_eq!(bucket.next_int(), 1);
+    ///
+    /// bucket.put(0_u64.to_be_bytes(), [0, 0]);
+    /// // not incremented after updating a key / value pair
+    /// assert_eq!(bucket.next_int(), 1);
+    ///
+    /// bucket.create_bucket("nested-bucket")?;
+    /// // auto-incremented after creating a nested bucket
+    /// assert_eq!(bucket.next_int(), 2);
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn next_int(&self) -> u64 {
+        self.inner.borrow().meta.next_int
+    }
 
-	pub(crate) fn rebalance(&mut self) -> Result<BucketMeta> {
-		self.inner.borrow_mut().rebalance()
-	}
+    pub(crate) fn rebalance(&mut self) -> Result<BucketMeta> {
+        self.inner.borrow_mut().rebalance()
+    }
 
-	pub(crate) fn write(&mut self, file: &mut File) -> Result<()> {
-		self.inner.borrow_mut().write(file)
-	}
+    pub(crate) fn write(&mut self, file: &mut File) -> Result<()> {
+        self.inner.borrow_mut().write(file)
+    }
 
-	#[doc(hidden)]
-	#[cfg_attr(tarpaulin, skip)]
-	pub(crate) fn print(&self) {
-		self.inner.borrow().print()
-	}
+    #[doc(hidden)]
+    #[cfg_attr(tarpaulin, skip)]
+    pub(crate) fn print(&self) {
+        self.inner.borrow().print()
+    }
 
-	pub(crate) fn meta(&self) -> BucketMeta {
-		self.inner.borrow().meta
-	}
+    pub(crate) fn meta(&self) -> BucketMeta {
+        self.inner.borrow().meta
+    }
 
-	/// Gets [`Data`] from a bucket.
-	///
-	/// Returns `None` if the key does not exist. Otherwise returns `Some(Data)` representing either a
-	/// key / value pair or a nested-bucket.
-	///
-	/// # Examples
-	///
-	/// ```no_run
-	/// use jammdb::{DB, Data};
-	/// # use jammdb::Error;
-	///
-	/// # fn main() -> Result<(), Error> {
-	/// let db = DB::open("my.db")?;
-	/// let mut tx = db.tx(false)?;
-	///
-	/// let bucket = tx.get_bucket("my-bucket")?;
-	///
-	/// match bucket.get("some-key") {
-	///     Some(data) => {
-	///         match &*data {
-	///             Data::Bucket(b) => println!("found a bucket with the name {:?}", b.name()),
-	///             Data::KeyValue(kv) => println!("found a kv pair {:?} {:?}", kv.key(), kv.value()),
-	///         }
-	///     },
-	///     None => println!("Key does not exist"),
-	/// }
-	///
-	/// # Ok(())
-	/// # }
-	/// ```
-	pub fn get<T: AsRef<[u8]>>(&self, key: T) -> Option<Ref<Data>> {
-		let mut c = self.cursor();
-		let exists = c.seek(key);
-		if exists {
-			c.current().map(Ref::new)
-		} else {
-			None
-		}
-	}
+    /// Gets [`Data`] from a bucket.
+    ///
+    /// Returns `None` if the key does not exist. Otherwise returns `Some(Data)` representing either a
+    /// key / value pair or a nested-bucket.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use jammdb::{DB, Data};
+    /// # use jammdb::Error;
+    ///
+    /// # fn main() -> Result<(), Error> {
+    /// let db = DB::open("my.db")?;
+    /// let mut tx = db.tx(false)?;
+    ///
+    /// let bucket = tx.get_bucket("my-bucket")?;
+    ///
+    /// match bucket.get("some-key") {
+    ///     Some(data) => {
+    ///         match &*data {
+    ///             Data::Bucket(b) => println!("found a bucket with the name {:?}", b.name()),
+    ///             Data::KeyValue(kv) => println!("found a kv pair {:?} {:?}", kv.key(), kv.value()),
+    ///         }
+    ///     },
+    ///     None => println!("Key does not exist"),
+    /// }
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn get<T: AsRef<[u8]>>(&self, key: T) -> Option<Ref<Data>> {
+        let mut c = self.cursor();
+        let exists = c.seek(key);
+        if exists {
+            c.current().map(Ref::new)
+        } else {
+            None
+        }
+    }
 
-	/// Gets a key / value pair from a bucket.
-	///
-	/// Returns `None` if the key does not exist, or if the key is for a nested bucket.
-	///
-	/// # Examples
-	///
-	/// ```no_run
-	/// use jammdb::{DB, Data};
-	/// # use jammdb::Error;
-	///
-	/// # fn main() -> Result<(), Error> {
-	/// let db = DB::open("my.db")?;
-	/// let mut tx = db.tx(false)?;
-	///
-	/// let bucket = tx.get_bucket("my-bucket")?;
-	/// bucket.create_bucket("sub-bucket")?;
-	/// bucket.put("some-key", "some-value")?;
-	///
-	/// if let Some(kv) = bucket.get_kv("some-key") {
-	///     assert_eq!(kv.value(), b"some-value");
-	/// }
-	/// assert!(bucket.get("sub-bucket").is_some());
-	/// assert!(bucket.get_kv("sub-bucket").is_none());
-	///
-	/// # Ok(())
-	/// # }
-	/// ```
-	pub fn get_kv<T: AsRef<[u8]>>(&self, key: T) -> Option<Ref<KVPair>> {
-		match self.get(key) {
-			Some(data) => match &*data {
-				Data::KeyValue(kv) => Some(Ref::new(kv.clone())),
-				_ => None,
-			},
-			_ => None,
-		}
-	}
+    /// Gets a key / value pair from a bucket.
+    ///
+    /// Returns `None` if the key does not exist, or if the key is for a nested bucket.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use jammdb::{DB, Data};
+    /// # use jammdb::Error;
+    ///
+    /// # fn main() -> Result<(), Error> {
+    /// let db = DB::open("my.db")?;
+    /// let mut tx = db.tx(false)?;
+    ///
+    /// let bucket = tx.get_bucket("my-bucket")?;
+    /// bucket.create_bucket("sub-bucket")?;
+    /// bucket.put("some-key", "some-value")?;
+    ///
+    /// if let Some(kv) = bucket.get_kv("some-key") {
+    ///     assert_eq!(kv.value(), b"some-value");
+    /// }
+    /// assert!(bucket.get("sub-bucket").is_some());
+    /// assert!(bucket.get_kv("sub-bucket").is_none());
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn get_kv<T: AsRef<[u8]>>(&self, key: T) -> Option<Ref<KVPair>> {
+        match self.get(key) {
+            Some(data) => match &*data {
+                Data::KeyValue(kv) => Some(Ref::new(kv.clone())),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Iterator over the sub-buckets in this bucket.
+    pub fn sub_buckets(&self) -> impl Iterator<Item = (Ref<BucketData>, BucketRef)> {
+        Buckets { c: self.cursor() }
+    }
+
+    /// Iterator over the key / value pairs in this bucket.
+    pub fn kv_pairs(&self) -> impl Iterator<Item = Ref<KVPair>> {
+        KVPairs { c: self.cursor() }
+    }
 }
 
 pub(crate) struct BucketInner {
-	pub(crate) tx: Ptr<TransactionInner>,
-	pub(crate) meta: BucketMeta,
-	pub(crate) root: PageNodeID,
-	dirty: bool,
-	buckets: HashMap<Vec<u8>, Pin<Box<Bucket>>>,
-	nodes: Vec<Pin<Box<Node>>>,
-	page_node_ids: HashMap<PageID, NodeID>,
-	page_parents: HashMap<PageID, PageID>,
+    pub(crate) tx: Ptr<TransactionInner>,
+    pub(crate) meta: BucketMeta,
+    pub(crate) root: PageNodeID,
+    dirty: bool,
+    buckets: HashMap<Vec<u8>, Pin<Box<Bucket>>>,
+    nodes: Vec<Pin<Box<Node>>>,
+    page_node_ids: HashMap<PageID, NodeID>,
+    page_parents: HashMap<PageID, PageID>,
 }
 
 impl BucketInner {
-	fn new_child(&mut self, name: &[u8]) {
-		let b = Bucket::new(BucketInner {
-			tx: Ptr::new(&self.tx),
-			meta: BucketMeta::default(),
-			root: PageNodeID::Node(0),
-			dirty: true,
-			buckets: HashMap::new(),
-			nodes: Vec::new(),
-			page_node_ids: HashMap::new(),
-			page_parents: HashMap::new(),
-		});
-		self.buckets.insert(Vec::from(name), Pin::new(Box::new(b)));
-		let b = self.buckets.get_mut(name).unwrap();
-		let mut b = b.inner.borrow_mut();
-		let n = Node::new(0, Page::TYPE_LEAF, Ptr::new(&b));
-		b.nodes.push(Pin::new(Box::new(n)));
-		b.page_node_ids.insert(0, 0);
-	}
+    fn new_child(&mut self, name: &[u8]) {
+        let b = Bucket::new(BucketInner {
+            tx: Ptr::new(&self.tx),
+            meta: BucketMeta::default(),
+            root: PageNodeID::Node(0),
+            dirty: true,
+            buckets: HashMap::new(),
+            nodes: Vec::new(),
+            page_node_ids: HashMap::new(),
+            page_parents: HashMap::new(),
+        });
+        self.buckets.insert(Vec::from(name), Pin::new(Box::new(b)));
+        let b = self.buckets.get_mut(name).unwrap();
+        let mut b = b.inner.borrow_mut();
+        let n = Node::new(0, Page::TYPE_LEAF, Ptr::new(&b));
+        b.nodes.push(Pin::new(Box::new(n)));
+        b.page_node_ids.insert(0, 0);
+    }
 
-	pub(crate) fn new_node(&mut self, data: NodeData) -> &mut Node {
-		let node_id = self.nodes.len() as u64;
-		let n = Node::with_data(node_id, data, Ptr::new(self));
-		self.nodes.push(Pin::new(Box::new(n)));
-		self.nodes.get_mut(node_id as usize).unwrap()
-	}
+    pub(crate) fn new_node(&mut self, data: NodeData) -> &mut Node {
+        let node_id = self.nodes.len() as u64;
+        let n = Node::with_data(node_id, data, Ptr::new(self));
+        self.nodes.push(Pin::new(Box::new(n)));
+        self.nodes.get_mut(node_id as usize).unwrap()
+    }
 
-	fn from_meta(&self, meta: BucketMeta) -> BucketInner {
-		BucketInner {
-			tx: Ptr::new(&self.tx),
-			meta,
-			root: PageNodeID::Page(meta.root_page),
-			dirty: false,
-			buckets: HashMap::new(),
-			nodes: Vec::new(),
-			page_node_ids: HashMap::new(),
-			page_parents: HashMap::new(),
-		}
-	}
+    fn from_meta(&self, meta: BucketMeta) -> BucketInner {
+        BucketInner {
+            tx: Ptr::new(&self.tx),
+            meta,
+            root: PageNodeID::Page(meta.root_page),
+            dirty: false,
+            buckets: HashMap::new(),
+            nodes: Vec::new(),
+            page_node_ids: HashMap::new(),
+            page_parents: HashMap::new(),
+        }
+    }
 
-	fn create_bucket<T: AsRef<[u8]>>(&mut self, name: T) -> Result<BucketRef> {
-		if !self.tx.writable {
-			return Err(Error::ReadOnlyTx);
-		}
-		self.bucket_getter(name.as_ref(), true, true)
-	}
+    fn create_bucket<T: AsRef<[u8]>>(&mut self, name: T) -> Result<BucketRef> {
+        if !self.tx.writable {
+            return Err(Error::ReadOnlyTx);
+        }
+        self.bucket_getter(name.as_ref(), true, true)
+    }
 
-	fn get_bucket<T: AsRef<[u8]>>(&mut self, name: T) -> Result<BucketRef> {
-		self.bucket_getter(name.as_ref(), false, false)
-	}
+    pub(crate) fn get_bucket<T: AsRef<[u8]>>(&mut self, name: T) -> Result<BucketRef> {
+        self.bucket_getter(name.as_ref(), false, false)
+    }
 
-	fn get_or_create_bucket<T: AsRef<[u8]>>(&mut self, name: T) -> Result<BucketRef> {
-		if !self.tx.writable {
-			return Err(Error::ReadOnlyTx);
-		}
-		self.bucket_getter(name.as_ref(), true, false)
-	}
+    fn get_or_create_bucket<T: AsRef<[u8]>>(&mut self, name: T) -> Result<BucketRef> {
+        if !self.tx.writable {
+            return Err(Error::ReadOnlyTx);
+        }
+        self.bucket_getter(name.as_ref(), true, false)
+    }
 
-	fn bucket_getter(
-		&mut self,
-		name: &[u8],
-		should_create: bool,
-		must_create: bool,
-	) -> Result<BucketRef> {
-		let key = Vec::from(name);
-		if !self.buckets.contains_key(&key) {
-			let mut c = self.cursor();
-			let exists = c.seek(name);
-			let current_id = c.current_id();
-			if !exists {
-				if should_create {
-					self.meta.next_int += 1;
-					let key = Vec::from(name);
-					self.new_child(&key);
-					let data = {
-						let b = self.buckets.get(&key).unwrap();
-						let b = b.inner.borrow_mut();
-						let key = self.tx.copy_data(name);
-						Data::Bucket(BucketData::from_meta(key, &b.meta))
-					};
-					let node = self.node(current_id);
-					node.insert_data(data);
-				} else {
-					return Err(Error::BucketMissing);
-				}
-			} else {
-				match c.current() {
-					Some(data) => match data {
-						Data::Bucket(data) => {
-							if must_create {
-								return Err(Error::BucketExists);
-							}
-							let mut b = self.from_meta(data.meta());
-							b.meta = data.meta();
-							b.dirty = false;
-							self.buckets
-								.insert(key.clone(), Pin::new(Box::new(Bucket::new(b))));
-						}
-						_ => return Err(Error::IncompatibleValue),
-					},
-					None => return Err(Error::BucketMissing),
-				}
-			}
-		} else if must_create {
-			return Err(Error::BucketExists);
-		}
-		Ok(BucketRef::new(self.buckets.get(&key).unwrap()))
-	}
+    fn bucket_getter(
+        &mut self,
+        name: &[u8],
+        should_create: bool,
+        must_create: bool,
+    ) -> Result<BucketRef> {
+        let key = Vec::from(name);
+        if !self.buckets.contains_key(&key) {
+            let mut c = self.cursor();
+            let exists = c.seek(name);
+            let current_id = c.current_id();
+            if !exists {
+                if should_create {
+                    self.meta.next_int += 1;
+                    let key = Vec::from(name);
+                    self.new_child(&key);
+                    let data = {
+                        let b = self.buckets.get(&key).unwrap();
+                        let b = b.inner.borrow_mut();
+                        let key = self.tx.copy_data(name);
+                        Data::Bucket(BucketData::from_meta(key, &b.meta))
+                    };
+                    let node = self.node(current_id);
+                    node.insert_data(data);
+                } else {
+                    return Err(Error::BucketMissing);
+                }
+            } else {
+                match c.current() {
+                    Some(data) => match data {
+                        Data::Bucket(data) => {
+                            if must_create {
+                                return Err(Error::BucketExists);
+                            }
+                            let mut b = self.from_meta(data.meta());
+                            b.meta = data.meta();
+                            b.dirty = false;
+                            self.buckets
+                                .insert(key.clone(), Pin::new(Box::new(Bucket::new(b))));
+                        }
+                        _ => return Err(Error::IncompatibleValue),
+                    },
+                    None => return Err(Error::BucketMissing),
+                }
+            }
+        } else if must_create {
+            return Err(Error::BucketExists);
+        }
+        Ok(BucketRef::new(self.buckets.get(&key).unwrap()))
+    }
 
-	fn delete_bucket<T: AsRef<[u8]>>(&mut self, name: T) -> Result<()> {
-		if !self.tx.writable {
-			return Err(Error::ReadOnlyTx);
-		}
-		// make sure the bucket is in our map
-		self.get_bucket(&name)?;
-		// remove the bucket from the map so it will be dropped at the end of this function
-		let b = self.buckets.remove(&Vec::from(name.as_ref())).unwrap();
-		let b = Pin::into_inner(b);
-		let b = b.inner.borrow_mut();
-		// check that the bucket wasn't just created and never comitted
-		let mut remaining_pages = Vec::new();
-		if b.meta.root_page != 0 {
-			// create a stack of pages to free and keep going until
-			// we've freed every reachable page starting from this bucket's root page
-			remaining_pages.push(b.meta.root_page);
-			while !remaining_pages.is_empty() {
-				let page_id = remaining_pages.pop().unwrap();
-				let page = self.tx.page(page_id);
-				let num_pages = page.overflow + 1;
-				match page.page_type {
-					// every branch element's page much be freed
-					Page::TYPE_BRANCH => {
-						page.branch_elements()
-							.iter()
-							.for_each(|b| remaining_pages.push(b.page));
-					}
-					Page::TYPE_LEAF => {
-						// every nested bucket's pages must be freed
-						page.leaf_elements().iter().for_each(|leaf| {
-							if leaf.node_type == Node::TYPE_BUCKET {
-								let bucket_data = BucketData::new(leaf.key(), leaf.value());
-								remaining_pages.push(bucket_data.meta().root_page);
-							}
-						});
-					}
-					_ => (),
-				}
-				self.tx.free(page_id, num_pages);
-			}
-		}
-		// delete the element from this bucket
-		let mut c = self.cursor();
-		let exists = c.seek(&name);
-		if exists {
-			let data = c.current().unwrap();
-			let current_id = c.current_id();
-			let index = c.current_index();
-			if !data.is_kv() {
-				self.dirty = true;
-				let node = self.node(current_id);
-				node.delete(index);
-				Ok(())
-			} else {
-				Err(Error::IncompatibleValue)
-			}
-		} else {
-			Err(Error::KeyValueMissing)
-		}
-	}
+    fn delete_bucket<T: AsRef<[u8]>>(&mut self, name: T) -> Result<()> {
+        if !self.tx.writable {
+            return Err(Error::ReadOnlyTx);
+        }
+        // make sure the bucket is in our map
+        self.get_bucket(&name)?;
+        // remove the bucket from the map so it will be dropped at the end of this function
+        let b = self.buckets.remove(&Vec::from(name.as_ref())).unwrap();
+        let b = Pin::into_inner(b);
+        let b = b.inner.borrow_mut();
+        // check that the bucket wasn't just created and never comitted
+        let mut remaining_pages = Vec::new();
+        if b.meta.root_page != 0 {
+            // create a stack of pages to free and keep going until
+            // we've freed every reachable page starting from this bucket's root page
+            remaining_pages.push(b.meta.root_page);
+            while !remaining_pages.is_empty() {
+                let page_id = remaining_pages.pop().unwrap();
+                let page = self.tx.page(page_id);
+                let num_pages = page.overflow + 1;
+                match page.page_type {
+                    // every branch element's page much be freed
+                    Page::TYPE_BRANCH => {
+                        page.branch_elements()
+                            .iter()
+                            .for_each(|b| remaining_pages.push(b.page));
+                    }
+                    Page::TYPE_LEAF => {
+                        // every nested bucket's pages must be freed
+                        page.leaf_elements().iter().for_each(|leaf| {
+                            if leaf.node_type == Node::TYPE_BUCKET {
+                                let bucket_data = BucketData::new(leaf.key(), leaf.value());
+                                remaining_pages.push(bucket_data.meta().root_page);
+                            }
+                        });
+                    }
+                    _ => (),
+                }
+                self.tx.free(page_id, num_pages);
+            }
+        }
+        // delete the element from this bucket
+        let mut c = self.cursor();
+        let exists = c.seek(&name);
+        if exists {
+            let data = c.current().unwrap();
+            let current_id = c.current_id();
+            let index = c.current_index();
+            if !data.is_kv() {
+                self.dirty = true;
+                let node = self.node(current_id);
+                node.delete(index);
+                Ok(())
+            } else {
+                Err(Error::IncompatibleValue)
+            }
+        } else {
+            Err(Error::KeyValueMissing)
+        }
+    }
 
-	fn put<T: AsRef<[u8]>, S: AsRef<[u8]>>(&mut self, key: T, value: S) -> Result<Option<KVPair>> {
-		if !self.tx.writable {
-			return Err(Error::ReadOnlyTx);
-		}
-		let k = self.tx.copy_data(key.as_ref());
-		let v = self.tx.copy_data(value.as_ref());
-		match self.put_data(Data::KeyValue(KVPair::from_slice_parts(k, v)))? {
-			Some(data) => match data {
-				Data::KeyValue(kv) => Ok(Some(kv)),
-				_ => panic!("Unexpected data"),
-			},
-			None => Ok(None),
-		}
-	}
+    fn put<T: AsRef<[u8]>, S: AsRef<[u8]>>(&mut self, key: T, value: S) -> Result<Option<KVPair>> {
+        if !self.tx.writable {
+            return Err(Error::ReadOnlyTx);
+        }
+        let k = self.tx.copy_data(key.as_ref());
+        let v = self.tx.copy_data(value.as_ref());
+        match self.put_data(Data::KeyValue(KVPair::from_slice_parts(k, v)))? {
+            Some(data) => match data {
+                Data::KeyValue(kv) => Ok(Some(kv)),
+                _ => panic!("Unexpected data"),
+            },
+            None => Ok(None),
+        }
+    }
 
-	fn delete<T: AsRef<[u8]>>(&mut self, key: T) -> Result<KVPair> {
-		if !self.tx.writable {
-			return Err(Error::ReadOnlyTx);
-		}
-		let mut c = self.cursor();
-		let exists = c.seek(key);
-		if exists {
-			let data = c.current().unwrap();
-			if data.is_kv() {
-				let current_id = c.current_id();
-				let index = c.current_index();
-				self.dirty = true;
-				let node = self.node(current_id);
-				match node.delete(index) {
-					Data::KeyValue(kv) => Ok(kv),
-					_ => panic!("Unexpected data"),
-				}
-			} else {
-				Err(Error::IncompatibleValue)
-			}
-		} else {
-			Err(Error::KeyValueMissing)
-		}
-	}
+    fn delete<T: AsRef<[u8]>>(&mut self, key: T) -> Result<KVPair> {
+        if !self.tx.writable {
+            return Err(Error::ReadOnlyTx);
+        }
+        let mut c = self.cursor();
+        let exists = c.seek(key);
+        if exists {
+            let data = c.current().unwrap();
+            if data.is_kv() {
+                let current_id = c.current_id();
+                let index = c.current_index();
+                self.dirty = true;
+                let node = self.node(current_id);
+                match node.delete(index) {
+                    Data::KeyValue(kv) => Ok(kv),
+                    _ => panic!("Unexpected data"),
+                }
+            } else {
+                Err(Error::IncompatibleValue)
+            }
+        } else {
+            Err(Error::KeyValueMissing)
+        }
+    }
 
-	fn put_data(&mut self, data: Data) -> Result<Option<Data>> {
-		let mut c = self.cursor();
-		let exists = c.seek(data.key());
-		let current_id = c.current_id();
-		let current_data = if exists {
-			let current = c.current().unwrap();
-			if current.is_kv() != data.is_kv() {
-				return Err(Error::IncompatibleValue);
-			}
-			Some(current)
-		} else {
-			self.meta.next_int += 1;
-			None
-		};
-		let node = self.node(current_id);
-		node.insert_data(data);
-		self.dirty = true;
-		Ok(current_data)
-	}
+    fn put_data(&mut self, data: Data) -> Result<Option<Data>> {
+        let mut c = self.cursor();
+        let exists = c.seek(data.key());
+        let current_id = c.current_id();
+        let current_data = if exists {
+            let current = c.current().unwrap();
+            if current.is_kv() != data.is_kv() {
+                return Err(Error::IncompatibleValue);
+            }
+            Some(current)
+        } else {
+            self.meta.next_int += 1;
+            None
+        };
+        let node = self.node(current_id);
+        node.insert_data(data);
+        self.dirty = true;
+        Ok(current_data)
+    }
 
-	fn cursor(&self) -> Cursor {
-		Cursor::new(Ptr::new(self))
-	}
+    fn cursor(&self) -> Cursor {
+        Cursor::new(Ptr::new(self))
+    }
 
-	pub(crate) fn page_node(&self, page: PageID) -> PageNode {
-		if let Some(node_id) = self.page_node_ids.get(&page) {
-			PageNode::Node(Ptr::new(self.nodes.get(*node_id as usize).unwrap()))
-		} else {
-			PageNode::Page(Ptr::new(self.tx.page(page)))
-		}
-	}
+    pub(crate) fn page_node(&self, page: PageID) -> PageNode {
+        if let Some(node_id) = self.page_node_ids.get(&page) {
+            PageNode::Node(Ptr::new(self.nodes.get(*node_id as usize).unwrap()))
+        } else {
+            PageNode::Page(Ptr::new(self.tx.page(page)))
+        }
+    }
 
-	pub(crate) fn add_page_parent(&mut self, page: PageID, parent: PageID) {
-		debug_assert!(self.meta.root_page == parent || self.page_parents.contains_key(&parent));
-		self.page_parents.insert(page, parent);
-	}
+    pub(crate) fn add_page_parent(&mut self, page: PageID, parent: PageID) {
+        debug_assert!(self.meta.root_page == parent || self.page_parents.contains_key(&parent));
+        self.page_parents.insert(page, parent);
+    }
 
-	pub(crate) fn node(&mut self, id: PageNodeID) -> &mut Node {
-		let id: NodeID = match id {
-			PageNodeID::Page(page_id) => {
-				if let Some(node_id) = self.page_node_ids.get(&page_id) {
-					return &mut self.nodes[*node_id as usize];
-				}
-				debug_assert!(
-					self.meta.root_page == page_id || self.page_parents.contains_key(&page_id)
-				);
-				let node_id = self.nodes.len() as u64;
-				self.page_node_ids.insert(page_id, node_id);
-				let n: Node = Node::from_page(node_id, Ptr::new(self), self.tx.page(page_id));
-				self.nodes.push(Pin::new(Box::new(n)));
-				if self.meta.root_page != page_id {
-					let node_key = self.nodes[node_id as usize].data.key_parts();
-					let parent = self.node(PageNodeID::Page(self.page_parents[&page_id]));
-					parent.insert_child(node_id, node_key);
-				}
-				node_id
-			}
-			PageNodeID::Node(id) => id,
-		};
-		self.nodes.get_mut(id as usize).unwrap()
-	}
+    pub(crate) fn node(&mut self, id: PageNodeID) -> &mut Node {
+        let id: NodeID = match id {
+            PageNodeID::Page(page_id) => {
+                if let Some(node_id) = self.page_node_ids.get(&page_id) {
+                    return &mut self.nodes[*node_id as usize];
+                }
+                debug_assert!(
+                    self.meta.root_page == page_id || self.page_parents.contains_key(&page_id)
+                );
+                let node_id = self.nodes.len() as u64;
+                self.page_node_ids.insert(page_id, node_id);
+                let n: Node = Node::from_page(node_id, Ptr::new(self), self.tx.page(page_id));
+                self.nodes.push(Pin::new(Box::new(n)));
+                if self.meta.root_page != page_id {
+                    let node_key = self.nodes[node_id as usize].data.key_parts();
+                    let parent = self.node(PageNodeID::Page(self.page_parents[&page_id]));
+                    parent.insert_child(node_id, node_key);
+                }
+                node_id
+            }
+            PageNodeID::Node(id) => id,
+        };
+        self.nodes.get_mut(id as usize).unwrap()
+    }
 
-	fn rebalance(&mut self) -> Result<BucketMeta> {
-		let mut bucket_metas = HashMap::new();
-		for (key, b) in self.buckets.iter_mut() {
-			let b = b.inner.get_mut();
-			if b.dirty {
-				self.dirty = true;
-				let bucket_meta = b.rebalance()?;
-				bucket_metas.insert(key.clone(), bucket_meta);
-			}
-		}
-		for (k, b) in bucket_metas {
-			let name = self.tx.copy_data(&k[..]);
-			let meta = self.tx.copy_data(b.as_ref());
-			self.put_data(Data::Bucket(BucketData::from_slice_parts(name, meta)))?;
-		}
-		if self.dirty {
-			// merge emptyish nodes first
-			{
-				let mut root_node = self.node(self.root);
-				let should_merge_root = root_node.merge();
-				// check if the root is a bucket and only has one node
-				if should_merge_root && !root_node.leaf() && root_node.data.len() == 1 {
-					// remove the branch and make the leaf node the root
-					root_node.free_page();
-					root_node.deleted = true;
-					let page_id = match &root_node.data {
-						NodeData::Branches(branches) => branches[0].page,
-						_ => panic!("uh wat"),
-					};
-					self.meta.root_page = page_id;
-					self.root = PageNodeID::Page(page_id);
-					// if the new root hasn't been modified, no need to split it
-					if !self.page_node_ids.contains_key(&page_id) {
-						self.dirty = false;
-						return Ok(self.meta);
-					}
-					// otherwise we'll continue to possibly split the new root
-					// this could result in re-adding a branch root node,
-					// but it's pretty unlikely!
-				}
-			}
-			// split overflowing nodes
-			{
-				let mut root_node = self.node(self.root);
-				while let Some(mut branches) = root_node.split() {
-					branches.insert(0, Branch::from_node(root_node));
-					root_node = self.new_node(NodeData::Branches(branches));
-				}
-				let page_id = root_node.page_id;
-				self.root = PageNodeID::Node(root_node.page_id);
-				self.meta.root_page = page_id;
-			}
-		}
-		Ok(self.meta)
-	}
+    fn rebalance(&mut self) -> Result<BucketMeta> {
+        let mut bucket_metas = HashMap::new();
+        for (key, b) in self.buckets.iter_mut() {
+            let b = b.inner.get_mut();
+            if b.dirty {
+                self.dirty = true;
+                let bucket_meta = b.rebalance()?;
+                bucket_metas.insert(key.clone(), bucket_meta);
+            }
+        }
+        for (k, b) in bucket_metas {
+            let name = self.tx.copy_data(&k[..]);
+            let meta = self.tx.copy_data(b.as_ref());
+            self.put_data(Data::Bucket(BucketData::from_slice_parts(name, meta)))?;
+        }
+        if self.dirty {
+            // merge emptyish nodes first
+            {
+                let mut root_node = self.node(self.root);
+                let should_merge_root = root_node.merge();
+                // check if the root is a bucket and only has one node
+                if should_merge_root && !root_node.leaf() && root_node.data.len() == 1 {
+                    // remove the branch and make the leaf node the root
+                    root_node.free_page();
+                    root_node.deleted = true;
+                    let page_id = match &root_node.data {
+                        NodeData::Branches(branches) => branches[0].page,
+                        _ => panic!("uh wat"),
+                    };
+                    self.meta.root_page = page_id;
+                    self.root = PageNodeID::Page(page_id);
+                    // if the new root hasn't been modified, no need to split it
+                    if !self.page_node_ids.contains_key(&page_id) {
+                        self.dirty = false;
+                        return Ok(self.meta);
+                    }
+                    // otherwise we'll continue to possibly split the new root
+                    // this could result in re-adding a branch root node,
+                    // but it's pretty unlikely!
+                }
+            }
+            // split overflowing nodes
+            {
+                let mut root_node = self.node(self.root);
+                while let Some(mut branches) = root_node.split() {
+                    branches.insert(0, Branch::from_node(root_node));
+                    root_node = self.new_node(NodeData::Branches(branches));
+                }
+                let page_id = root_node.page_id;
+                self.root = PageNodeID::Node(root_node.page_id);
+                self.meta.root_page = page_id;
+            }
+        }
+        Ok(self.meta)
+    }
 
-	pub(crate) fn write(&mut self, file: &mut File) -> Result<()> {
-		for (_, b) in self.buckets.iter_mut() {
-			b.inner.get_mut().write(file)?;
-		}
-		if self.dirty {
-			for node in self.nodes.iter_mut() {
-				if !node.deleted {
-					node.write(file)?;
-				}
-			}
-		}
-		Ok(())
-	}
+    pub(crate) fn write(&mut self, file: &mut File) -> Result<()> {
+        for (_, b) in self.buckets.iter_mut() {
+            b.inner.get_mut().write(file)?;
+        }
+        if self.dirty {
+            for node in self.nodes.iter_mut() {
+                if !node.deleted {
+                    node.write(file)?;
+                }
+            }
+        }
+        Ok(())
+    }
 
-	#[doc(hidden)]
-	#[cfg_attr(tarpaulin, skip)]
-	fn print(&self) {
-		let page = self.tx.page(self.meta.root_page);
-		page.print(&self.tx);
-	}
+    #[doc(hidden)]
+    #[cfg_attr(tarpaulin, skip)]
+    fn print(&self) {
+        let page = self.tx.page(self.meta.root_page);
+        page.print(&self.tx);
+    }
 }
 
 pub struct BucketRef<'a> {
-	bucket: *const Bucket,
-	_phantom: PhantomData<&'a ()>,
+    bucket: *const Bucket,
+    _phantom: PhantomData<&'a ()>,
 }
 
 impl<'a> BucketRef<'a> {
-	pub(crate) fn new(b: &Bucket) -> BucketRef {
-		BucketRef {
-			bucket: b as *const Bucket,
-			_phantom: PhantomData {},
-		}
-	}
+    pub(crate) fn new(b: &Bucket) -> BucketRef {
+        BucketRef {
+            bucket: b as *const Bucket,
+            _phantom: PhantomData {},
+        }
+    }
+
+    pub(crate) fn from_ptr<'b>(b: *const Bucket) -> BucketRef<'b> {
+        BucketRef {
+            bucket: b,
+            _phantom: PhantomData {},
+        }
+    }
 }
 
 impl<'a> Deref for BucketRef<'a> {
-	type Target = Bucket;
+    type Target = Bucket;
 
-	fn deref(&self) -> &Self::Target {
-		unsafe { &*self.bucket }
-	}
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.bucket }
+    }
 }
 
 impl<'a> DerefMut for BucketRef<'a> {
-	fn deref_mut(&mut self) -> &mut Self::Target {
-		unsafe { &mut *(self.bucket as *mut Bucket) }
-	}
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *(self.bucket as *mut Bucket) }
+    }
 }
 
 const META_SIZE: usize = std::mem::size_of::<BucketMeta>();
@@ -840,17 +857,33 @@ const META_SIZE: usize = std::mem::size_of::<BucketMeta>();
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct BucketMeta {
-	pub(crate) root_page: PageID,
-	pub(crate) next_int: u64,
+    pub(crate) root_page: PageID,
+    pub(crate) next_int: u64,
 }
 
 impl AsRef<[u8]> for BucketMeta {
-	#[inline]
-	fn as_ref(&self) -> &[u8] {
-		let ptr = self as *const BucketMeta as *const u8;
-		unsafe { std::slice::from_raw_parts(ptr, META_SIZE) }
-	}
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        let ptr = self as *const BucketMeta as *const u8;
+        unsafe { std::slice::from_raw_parts(ptr, META_SIZE) }
+    }
 }
+
+// pub struct BucketIter<'a> {
+//     b: &'a Bucket,
+//     i: Buckets<'a>,
+// }
+
+// impl<'a> Iterator for BucketIter<'a> {
+//     type Item = BucketRef<'a>;
+
+//     fn next(&mut self) -> Option<Self::Item> {
+//         match self.i.next() {
+//             Some(b) => self.b.get_bucket(b.name()).map(|b| Some(b)).unwrap_or(None),
+//             None => None,
+//         }
+//     }
+// }
 
 // #[cfg(test)]
 // mod tests {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,96 +1,102 @@
 use std::marker::PhantomData;
 
-use crate::bucket::BucketInner;
-use crate::data::{Data, Ref};
 use crate::node::{Node, NodeData, NodeID};
 use crate::page::{Page, PageID};
 use crate::ptr::Ptr;
+use crate::{
+    bucket::{BucketInner, BucketRef},
+    Bucket,
+};
+use crate::{
+    data::{Data, KVPair, Ref},
+    BucketData,
+};
 
 #[derive(Clone, Copy)]
 pub(crate) enum PageNodeID {
-	Page(PageID),
-	Node(NodeID),
+    Page(PageID),
+    Node(NodeID),
 }
 
 pub(crate) enum PageNode {
-	Page(Ptr<Page>),
-	Node(Ptr<Node>),
+    Page(Ptr<Page>),
+    Node(Ptr<Node>),
 }
 
 impl PageNode {
-	fn leaf(&self) -> bool {
-		match self {
-			PageNode::Page(p) => p.page_type == Page::TYPE_LEAF,
-			PageNode::Node(n) => n.leaf(),
-		}
-	}
+    fn leaf(&self) -> bool {
+        match self {
+            PageNode::Page(p) => p.page_type == Page::TYPE_LEAF,
+            PageNode::Node(n) => n.leaf(),
+        }
+    }
 
-	fn len(&self) -> usize {
-		match self {
-			PageNode::Page(p) => p.count as usize,
-			PageNode::Node(n) => n.data.len(),
-		}
-	}
+    fn len(&self) -> usize {
+        match self {
+            PageNode::Page(p) => p.count as usize,
+            PageNode::Node(n) => n.data.len(),
+        }
+    }
 
-	fn index_page(&self, index: usize) -> PageID {
-		match self {
-			PageNode::Page(p) => {
-				if index >= p.count as usize {
-					return 0;
-				}
-				match p.page_type {
-					Page::TYPE_BRANCH => p.branch_elements()[index].page,
-					_ => panic!("INVALID PAGE TYPE FOR INDEX_PAGE"),
-				}
-			}
-			PageNode::Node(n) => {
-				if index >= n.data.len() {
-					return 0;
-				}
-				match &n.data {
-					NodeData::Branches(b) => b[index].page,
-					_ => panic!("INVALID NODE TYPE FOR INDEX_PAGE"),
-				}
-			}
-		}
-	}
+    fn index_page(&self, index: usize) -> PageID {
+        match self {
+            PageNode::Page(p) => {
+                if index >= p.count as usize {
+                    return 0;
+                }
+                match p.page_type {
+                    Page::TYPE_BRANCH => p.branch_elements()[index].page,
+                    _ => panic!("INVALID PAGE TYPE FOR INDEX_PAGE"),
+                }
+            }
+            PageNode::Node(n) => {
+                if index >= n.data.len() {
+                    return 0;
+                }
+                match &n.data {
+                    NodeData::Branches(b) => b[index].page,
+                    _ => panic!("INVALID NODE TYPE FOR INDEX_PAGE"),
+                }
+            }
+        }
+    }
 
-	fn index(&self, key: &[u8]) -> (usize, bool) {
-		let result = match self {
-			PageNode::Page(p) => match p.page_type {
-				Page::TYPE_LEAF => p.leaf_elements().binary_search_by_key(&key, |e| e.key()),
-				Page::TYPE_BRANCH => p.branch_elements().binary_search_by_key(&key, |e| e.key()),
-				_ => panic!("INVALID PAGE TYPE FOR INDEX: {:?}", p.page_type),
-			},
-			PageNode::Node(n) => match &n.data {
-				NodeData::Branches(b) => b.binary_search_by_key(&key, |b| b.key()),
-				NodeData::Leaves(l) => l.binary_search_by_key(&key, |l| l.key()),
-			},
-		};
-		match result {
-			Ok(i) => (i, true),
-			// we didn't find the element, so point at the element just "before" the missing element
-			Err(mut i) => {
-				if i > 0 {
-					i -= 1;
-				};
-				(i, false)
-			}
-		}
-	}
+    fn index(&self, key: &[u8]) -> (usize, bool) {
+        let result = match self {
+            PageNode::Page(p) => match p.page_type {
+                Page::TYPE_LEAF => p.leaf_elements().binary_search_by_key(&key, |e| e.key()),
+                Page::TYPE_BRANCH => p.branch_elements().binary_search_by_key(&key, |e| e.key()),
+                _ => panic!("INVALID PAGE TYPE FOR INDEX: {:?}", p.page_type),
+            },
+            PageNode::Node(n) => match &n.data {
+                NodeData::Branches(b) => b.binary_search_by_key(&key, |b| b.key()),
+                NodeData::Leaves(l) => l.binary_search_by_key(&key, |l| l.key()),
+            },
+        };
+        match result {
+            Ok(i) => (i, true),
+            // we didn't find the element, so point at the element just "before" the missing element
+            Err(mut i) => {
+                if i > 0 {
+                    i -= 1;
+                };
+                (i, false)
+            }
+        }
+    }
 
-	fn val(&self, index: usize) -> Option<Data> {
-		match self {
-			PageNode::Page(p) => match p.page_type {
-				Page::TYPE_LEAF => p.leaf_elements().get(index).map(|e| Data::from_leaf(e)),
-				_ => panic!("INVALID PAGE TYPE FOR VAL"),
-			},
-			PageNode::Node(n) => match &n.data {
-				NodeData::Leaves(l) => l.get(index).cloned(),
-				_ => panic!("INVALID NODE TYPE FOR VAL"),
-			},
-		}
-	}
+    fn val(&self, index: usize) -> Option<Data> {
+        match self {
+            PageNode::Page(p) => match p.page_type {
+                Page::TYPE_LEAF => p.leaf_elements().get(index).map(|e| Data::from_leaf(e)),
+                _ => panic!("INVALID PAGE TYPE FOR VAL"),
+            },
+            PageNode::Node(n) => match &n.data {
+                NodeData::Leaves(l) => l.get(index).cloned(),
+                _ => panic!("INVALID NODE TYPE FOR VAL"),
+            },
+        }
+    }
 }
 
 /// An iterator over a bucket
@@ -135,127 +141,169 @@ impl PageNode {
 /// # }
 /// ```
 pub struct Cursor<'a> {
-	bucket: Ptr<BucketInner>,
-	stack: Vec<Elem>,
-	next_called: bool,
-	_phantom: PhantomData<&'a ()>,
+    bucket: Ptr<BucketInner>,
+    stack: Vec<Elem>,
+    next_called: bool,
+    _phantom: PhantomData<&'a ()>,
 }
 
 impl<'a> Cursor<'a> {
-	pub(crate) fn new(b: Ptr<BucketInner>) -> Cursor<'a> {
-		Cursor {
-			bucket: b,
-			stack: vec![],
-			next_called: false,
-			_phantom: PhantomData {},
-		}
-	}
+    pub(crate) fn new(b: Ptr<BucketInner>) -> Cursor<'a> {
+        Cursor {
+            bucket: b,
+            stack: vec![],
+            next_called: false,
+            _phantom: PhantomData {},
+        }
+    }
 
-	pub(crate) fn current_id(&self) -> PageNodeID {
-		let e = self.stack.last().unwrap();
-		match &e.page_node {
-			PageNode::Page(p) => PageNodeID::Page(p.id),
-			PageNode::Node(n) => PageNodeID::Node(n.id),
-		}
-	}
+    pub(crate) fn current_id(&self) -> PageNodeID {
+        let e = self.stack.last().unwrap();
+        match &e.page_node {
+            PageNode::Page(p) => PageNodeID::Page(p.id),
+            PageNode::Node(n) => PageNodeID::Node(n.id),
+        }
+    }
 
-	pub(crate) fn current_index(&self) -> usize {
-		let e = self.stack.last().unwrap();
-		e.index
-	}
+    pub(crate) fn current_index(&self) -> usize {
+        let e = self.stack.last().unwrap();
+        e.index
+    }
 
-	/// Moves the cursor to the given key.
-	/// If the key does not exist, the cursor stops "just before"
-	/// where the key _would_ be.
-	///
-	/// Returns whether or not the key exists in the bucket.
-	pub fn seek<T: AsRef<[u8]>>(&mut self, key: T) -> bool {
-		self.next_called = false;
-		self.stack.clear();
-		self.search(key.as_ref(), self.bucket.meta.root_page)
-	}
+    /// Moves the cursor to the given key.
+    /// If the key does not exist, the cursor stops "just before"
+    /// where the key _would_ be.
+    ///
+    /// Returns whether or not the key exists in the bucket.
+    pub fn seek<T: AsRef<[u8]>>(&mut self, key: T) -> bool {
+        self.next_called = false;
+        self.stack.clear();
+        self.search(key.as_ref(), self.bucket.meta.root_page)
+    }
 
-	/// Returns the data at the cursor's current position.
-	/// You can use this to get data after doing a [`seek`](#method.seek).
-	pub fn current(&self) -> Option<Data> {
-		match self.stack.last() {
-			Some(e) => e.page_node.val(e.index),
-			None => None,
-		}
-	}
+    /// Returns the data at the cursor's current position.
+    /// You can use this to get data after doing a [`seek`](#method.seek).
+    pub fn current(&self) -> Option<Data> {
+        match self.stack.last() {
+            Some(e) => e.page_node.val(e.index),
+            None => None,
+        }
+    }
 
-	// recursive function that searches the bucket for a given key
-	fn search(&mut self, key: &[u8], page_id: PageID) -> bool {
-		let page_node = self.bucket.page_node(page_id);
-		let (index, exact) = page_node.index(key);
-		let leaf = page_node.leaf();
-		self.stack.push(Elem { index, page_node });
-		if leaf {
-			return exact;
-		}
+    // recursive function that searches the bucket for a given key
+    fn search(&mut self, key: &[u8], page_id: PageID) -> bool {
+        let page_node = self.bucket.page_node(page_id);
+        let (index, exact) = page_node.index(key);
+        let leaf = page_node.leaf();
+        self.stack.push(Elem { index, page_node });
+        if leaf {
+            return exact;
+        }
 
-		let next_page_id = self.stack.last().unwrap().page_node.index_page(index);
-		if next_page_id == 0 {
-			return false;
-		}
-		self.bucket.add_page_parent(next_page_id, page_id);
+        let next_page_id = self.stack.last().unwrap().page_node.index_page(index);
+        if next_page_id == 0 {
+            return false;
+        }
+        self.bucket.add_page_parent(next_page_id, page_id);
 
-		self.search(key, next_page_id)
-	}
+        self.search(key, next_page_id)
+    }
 
-	pub(crate) fn seek_first(&mut self) {
-		if self.stack.is_empty() {
-			let page_node = self.bucket.page_node(self.bucket.meta.root_page);
-			self.stack.push(Elem {
-				index: 0,
-				page_node,
-			});
-		}
-		loop {
-			let elem = self.stack.last().unwrap();
-			if elem.page_node.leaf() {
-				break;
-			}
-			if elem.page_node.len() == 0 {
-				break;
-			}
-			let page_node = self.bucket.page_node(elem.page_node.index_page(elem.index));
-			self.stack.push(Elem {
-				index: 0,
-				page_node,
-			});
-		}
-	}
+    pub(crate) fn seek_first(&mut self) {
+        if self.stack.is_empty() {
+            let page_node = self.bucket.page_node(self.bucket.meta.root_page);
+            self.stack.push(Elem {
+                index: 0,
+                page_node,
+            });
+        }
+        loop {
+            let elem = self.stack.last().unwrap();
+            if elem.page_node.leaf() {
+                break;
+            }
+            if elem.page_node.len() == 0 {
+                break;
+            }
+            let page_node = self.bucket.page_node(elem.page_node.index_page(elem.index));
+            self.stack.push(Elem {
+                index: 0,
+                page_node,
+            });
+        }
+    }
 }
 
 impl<'a> Iterator for Cursor<'a> {
-	type Item = Ref<'a, Data>;
+    type Item = Ref<'a, Data>;
 
-	fn next(&mut self) -> Option<Self::Item> {
-		if self.stack.is_empty() {
-			self.seek_first();
-		} else if self.next_called {
-			loop {
-				let elem = self.stack.last_mut().unwrap();
-				if elem.index >= (elem.page_node.len() - 1) {
-					if self.stack.len() == 1 {
-						return None;
-					}
-					self.stack.pop();
-					continue;
-				} else {
-					elem.index += 1;
-				}
-				self.seek_first();
-				break;
-			}
-		}
-		self.next_called = true;
-		self.current().map(Ref::new)
-	}
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.stack.is_empty() {
+            self.seek_first();
+        } else if self.next_called {
+            loop {
+                let elem = self.stack.last_mut().unwrap();
+                if elem.index >= (elem.page_node.len() - 1) {
+                    if self.stack.len() == 1 {
+                        return None;
+                    }
+                    self.stack.pop();
+                    continue;
+                } else {
+                    elem.index += 1;
+                }
+                self.seek_first();
+                break;
+            }
+        }
+        self.next_called = true;
+        self.current().map(Ref::new)
+    }
 }
 
 struct Elem {
-	index: usize,
-	page_node: PageNode,
+    index: usize,
+    page_node: PageNode,
+}
+
+pub struct Buckets<'a> {
+    pub(crate) c: Cursor<'a>,
+}
+
+impl<'a> Iterator for Buckets<'a> {
+    type Item = (Ref<'a, BucketData>, BucketRef<'a>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.c.next() {
+            Some(r) => match &*r {
+                Data::Bucket(b) => match self.c.bucket.get_bucket(b.name()) {
+                    Ok(r) => Some((
+                        Ref::new(b.clone()),
+                        BucketRef::from_ptr::<'a>((&*r) as *const Bucket),
+                    )),
+                    _ => None,
+                },
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+
+pub struct KVPairs<'a> {
+    pub(crate) c: Cursor<'a>,
+}
+
+impl<'a> Iterator for KVPairs<'a> {
+    type Item = Ref<'a, KVPair>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.c.next() {
+            Some(r) => match &*r {
+                Data::KeyValue(kv) => Some(Ref::new(kv.clone())),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -45,86 +45,86 @@ const DEFAULT_NUM_PAGES: usize = 32;
 /// # }
 /// ```
 pub struct OpenOptions {
-	pagesize: u64,
-	num_pages: usize,
+    pagesize: u64,
+    num_pages: usize,
 }
 
 impl Default for OpenOptions {
-	fn default() -> Self {
-		let pagesize = getPageSize() as u64;
-		if pagesize < 1024 {
-			panic!("Pagesize must be 1024 bytes minimum");
-		}
-		OpenOptions {
-			pagesize,
-			num_pages: DEFAULT_NUM_PAGES,
-		}
-	}
+    fn default() -> Self {
+        let pagesize = getPageSize() as u64;
+        if pagesize < 1024 {
+            panic!("Pagesize must be 1024 bytes minimum");
+        }
+        OpenOptions {
+            pagesize,
+            num_pages: DEFAULT_NUM_PAGES,
+        }
+    }
 }
 
 impl OpenOptions {
-	/// Returns a new OpenOptions, with the default values.
-	pub fn new() -> Self {
-		Self::default()
-	}
+    /// Returns a new OpenOptions, with the default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
 
-	/// Sets the pagesize for the database
-	///
-	/// By default, your OS's pagesize is used as the database's pagesize, but if the file is
-	/// moved across systems with different page sizes, it is necessary to set the correct value.
-	/// Trying to open an existing database with the incorrect page size will result in a panic.
-	///
-	/// # Panics
-	/// Will panic if you try to set the pagesize < 1024 bytes.
-	pub fn pagesize(mut self, pagesize: u64) -> Self {
-		if pagesize < 1024 {
-			panic!("Pagesize must be 1024 bytes minimum");
-		}
-		self.pagesize = pagesize;
-		self
-	}
+    /// Sets the pagesize for the database
+    ///
+    /// By default, your OS's pagesize is used as the database's pagesize, but if the file is
+    /// moved across systems with different page sizes, it is necessary to set the correct value.
+    /// Trying to open an existing database with the incorrect page size will result in a panic.
+    ///
+    /// # Panics
+    /// Will panic if you try to set the pagesize < 1024 bytes.
+    pub fn pagesize(mut self, pagesize: u64) -> Self {
+        if pagesize < 1024 {
+            panic!("Pagesize must be 1024 bytes minimum");
+        }
+        self.pagesize = pagesize;
+        self
+    }
 
-	/// Sets the number of pages to allocate for a new database file.
-	///
-	/// The default `num_pages` is set to 32, so if your pagesize is 4096 bytes (4kb), then 131,072 bytes (128kb) will be allocated for the initial file.
-	/// Setting `num_pages` when opening an existing database has no effect.
-	///
-	/// # Panics
-	/// Since a minimum of four pages are required for the database, this function will panic if you provide a value < 4.
-	pub fn num_pages(mut self, num_pages: usize) -> Self {
-		if num_pages < 4 {
-			panic!("Must have a minimum of 4 pages");
-		}
-		self.num_pages = num_pages;
-		self
-	}
+    /// Sets the number of pages to allocate for a new database file.
+    ///
+    /// The default `num_pages` is set to 32, so if your pagesize is 4096 bytes (4kb), then 131,072 bytes (128kb) will be allocated for the initial file.
+    /// Setting `num_pages` when opening an existing database has no effect.
+    ///
+    /// # Panics
+    /// Since a minimum of four pages are required for the database, this function will panic if you provide a value < 4.
+    pub fn num_pages(mut self, num_pages: usize) -> Self {
+        if num_pages < 4 {
+            panic!("Must have a minimum of 4 pages");
+        }
+        self.num_pages = num_pages;
+        self
+    }
 
-	/// Opens the database with the current options.
-	///
-	/// If the file does not exist, it will initialize an empty database with a size of (`num_pages * pagesize`) bytes.
-	/// If it does exist, the file is opened with both read and write permissions, and we attempt to create an
-	/// [exclusive lock](https://en.wikipedia.org/wiki/File_locking) on the file. Getting the file lock will block until the lock
-	/// is released to prevent you from having two processes modifying the file at the same time. This lock is not foolproof though,
-	/// so it is up to the user to make sure only one process has access to the database at a time (unless it is read-only).
-	///
-	/// # Errors
-	///
-	/// Will return an error if there are issues creating a new file, opening an existing file, obtaining the file lock, or creating the memory map.
-	///
-	/// # Panics
-	///
-	/// Will panic if the pagesize the database is opened with is not the same as the pagesize it was created with.
-	pub fn open<P: AsRef<Path>>(self, path: P) -> Result<DB> {
-		let path: &Path = path.as_ref();
-		let file = if !path.exists() {
-			init_file(path, self.pagesize, self.num_pages)?
-		} else {
-			FileOpenOptions::new().read(true).write(true).open(path)?
-		};
+    /// Opens the database with the current options.
+    ///
+    /// If the file does not exist, it will initialize an empty database with a size of (`num_pages * pagesize`) bytes.
+    /// If it does exist, the file is opened with both read and write permissions, and we attempt to create an
+    /// [exclusive lock](https://en.wikipedia.org/wiki/File_locking) on the file. Getting the file lock will block until the lock
+    /// is released to prevent you from having two processes modifying the file at the same time. This lock is not foolproof though,
+    /// so it is up to the user to make sure only one process has access to the database at a time (unless it is read-only).
+    ///
+    /// # Errors
+    ///
+    /// Will return an error if there are issues creating a new file, opening an existing file, obtaining the file lock, or creating the memory map.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the pagesize the database is opened with is not the same as the pagesize it was created with.
+    pub fn open<P: AsRef<Path>>(self, path: P) -> Result<DB> {
+        let path: &Path = path.as_ref();
+        let file = if !path.exists() {
+            init_file(path, self.pagesize, self.num_pages)?
+        } else {
+            FileOpenOptions::new().read(true).write(true).open(path)?
+        };
 
-		let db = DBInner::open(file, self.pagesize)?;
-		Ok(DB(Arc::new(db)))
-	}
+        let db = DBInner::open(file, self.pagesize)?;
+        Ok(DB(Arc::new(db)))
+    }
 }
 
 /// A database
@@ -137,241 +137,241 @@ impl OpenOptions {
 pub struct DB(Arc<DBInner>);
 
 impl DB {
-	/// Opens a database using the default [`OpenOptions`].
-	///
-	/// Same as calling `OpenOptions::new().open(path)`.
-	/// Please read the documentation for [`OpenOptions::open`](struct.OpenOptions.html#method.open) for details.
-	///
-	/// # Examples
-	///
-	/// ```no_run
-	/// use jammdb::{DB};
-	/// # use jammdb::Error;
-	///
-	/// # fn main() -> Result<(), Error> {
-	/// let db = DB::open("my.db")?;
-	///
-	/// // do whatever you want with the DB
-	/// # Ok(())
-	/// # }
-	/// ```
-	pub fn open<P: AsRef<Path>>(path: P) -> Result<DB> {
-		OpenOptions::new().open(path)
-	}
+    /// Opens a database using the default [`OpenOptions`].
+    ///
+    /// Same as calling `OpenOptions::new().open(path)`.
+    /// Please read the documentation for [`OpenOptions::open`](struct.OpenOptions.html#method.open) for details.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use jammdb::{DB};
+    /// # use jammdb::Error;
+    ///
+    /// # fn main() -> Result<(), Error> {
+    /// let db = DB::open("my.db")?;
+    ///
+    /// // do whatever you want with the DB
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<DB> {
+        OpenOptions::new().open(path)
+    }
 
-	/// Creates a [`Transaction`].
-	/// This transaction is either read-only or writable depending on the `writable` parameter.
-	/// Please read the docs on a [`Transaction`] for more details.
-	pub fn tx(&self, writable: bool) -> Result<Transaction> {
-		Transaction::new(&self.0, writable)
-	}
+    /// Creates a [`Transaction`].
+    /// This transaction is either read-only or writable depending on the `writable` parameter.
+    /// Please read the docs on a [`Transaction`] for more details.
+    pub fn tx(&self, writable: bool) -> Result<Transaction> {
+        Transaction::new(&self.0, writable)
+    }
 
-	/// Returns the database's pagesize.
-	pub fn pagesize(&self) -> u64 {
-		self.0.pagesize
-	}
+    /// Returns the database's pagesize.
+    pub fn pagesize(&self) -> u64 {
+        self.0.pagesize
+    }
 
-	#[doc(hidden)]
-	pub fn check(&self) -> Result<()> {
-		let tx = self.tx(false)?;
-		tx.check()
-	}
+    #[doc(hidden)]
+    pub fn check(&self) -> Result<()> {
+        let tx = self.tx(false)?;
+        tx.check()
+    }
 }
 
 pub(crate) struct DBInner {
-	pub(crate) data: Arc<Mmap>,
-	pub(crate) freelist: Freelist,
+    pub(crate) data: Arc<Mmap>,
+    pub(crate) freelist: Freelist,
 
-	pub(crate) file: Mutex<File>,
-	pub(crate) mmap_lock: Mutex<()>,
-	pub(crate) open_ro_txs: Mutex<Vec<u64>>,
+    pub(crate) file: Mutex<File>,
+    pub(crate) mmap_lock: Mutex<()>,
+    pub(crate) open_ro_txs: Mutex<Vec<u64>>,
 
-	pub(crate) pagesize: u64,
+    pub(crate) pagesize: u64,
 }
 
 impl DBInner {
-	pub(crate) fn open(file: File, pagesize: u64) -> Result<DBInner> {
-		file.lock_exclusive()?;
+    pub(crate) fn open(file: File, pagesize: u64) -> Result<DBInner> {
+        file.lock_exclusive()?;
 
-		let mmap = unsafe { Arc::new(Mmap::map(&file)?) };
+        let mmap = unsafe { Arc::new(Mmap::map(&file)?) };
 
-		let mut db = DBInner {
-			data: mmap,
-			freelist: Freelist::new(),
+        let mut db = DBInner {
+            data: mmap,
+            freelist: Freelist::new(),
 
-			file: Mutex::new(file),
-			mmap_lock: Mutex::new(()),
-			open_ro_txs: Mutex::new(Vec::new()),
+            file: Mutex::new(file),
+            mmap_lock: Mutex::new(()),
+            open_ro_txs: Mutex::new(Vec::new()),
 
-			pagesize,
-		};
+            pagesize,
+        };
 
-		let meta = db.meta();
-		let free_pages = Page::from_buf(&db.data, meta.freelist_page, pagesize).freelist();
+        let meta = db.meta();
+        let free_pages = Page::from_buf(&db.data, meta.freelist_page, pagesize).freelist();
 
-		if !free_pages.is_empty() {
-			db.freelist.init(free_pages);
-		}
+        if !free_pages.is_empty() {
+            db.freelist.init(free_pages);
+        }
 
-		Ok(db)
-	}
+        Ok(db)
+    }
 
-	pub(crate) fn resize(&mut self, file: &File, new_size: u64) -> Result<()> {
-		file.allocate(new_size)?;
-		let _lock = self.mmap_lock.lock()?;
-		let mmap = unsafe { Mmap::map(file).unwrap() };
-		self.data = Arc::new(mmap);
-		Ok(())
-	}
+    pub(crate) fn resize(&mut self, file: &File, new_size: u64) -> Result<()> {
+        file.allocate(new_size)?;
+        let _lock = self.mmap_lock.lock()?;
+        let mmap = unsafe { Mmap::map(file).unwrap() };
+        self.data = Arc::new(mmap);
+        Ok(())
+    }
 
-	pub(crate) fn meta(&self) -> Meta {
-		let meta1 = Page::from_buf(&self.data, 0, self.pagesize).meta();
-		let meta2 = Page::from_buf(&self.data, 1, self.pagesize).meta();
-		match (meta1.valid(), meta2.valid()) {
-			(true, true) => {
-				assert_eq!(
-					meta1.pagesize as u64, self.pagesize,
-					"Invalid pagesize from meta1 {}. Expected {}.",
-					meta1.pagesize, self.pagesize
-				);
-				assert_eq!(
-					meta2.pagesize as u64, self.pagesize,
-					"Invalid pagesize from meta2 {}. Expected {}.",
-					meta2.pagesize, self.pagesize
-				);
-				if meta1.tx_id > meta2.tx_id {
-					meta1
-				} else {
-					meta2
-				}
-			}
-			(true, false) => {
-				assert_eq!(
-					meta1.pagesize as u64, self.pagesize,
-					"Invalid pagesize from meta1 {}. Expected {}.",
-					meta1.pagesize, self.pagesize
-				);
-				meta1
-			}
-			(false, true) => {
-				assert_eq!(
-					meta2.pagesize as u64, self.pagesize,
-					"Invalid pagesize from meta2 {}. Expected {}.",
-					meta2.pagesize, self.pagesize
-				);
-				meta2
-			}
-			(false, false) => panic!("NO VALID META PAGES"),
-		}
-		.clone()
-	}
+    pub(crate) fn meta(&self) -> Meta {
+        let meta1 = Page::from_buf(&self.data, 0, self.pagesize).meta();
+        let meta2 = Page::from_buf(&self.data, 1, self.pagesize).meta();
+        match (meta1.valid(), meta2.valid()) {
+            (true, true) => {
+                assert_eq!(
+                    meta1.pagesize as u64, self.pagesize,
+                    "Invalid pagesize from meta1 {}. Expected {}.",
+                    meta1.pagesize, self.pagesize
+                );
+                assert_eq!(
+                    meta2.pagesize as u64, self.pagesize,
+                    "Invalid pagesize from meta2 {}. Expected {}.",
+                    meta2.pagesize, self.pagesize
+                );
+                if meta1.tx_id > meta2.tx_id {
+                    meta1
+                } else {
+                    meta2
+                }
+            }
+            (true, false) => {
+                assert_eq!(
+                    meta1.pagesize as u64, self.pagesize,
+                    "Invalid pagesize from meta1 {}. Expected {}.",
+                    meta1.pagesize, self.pagesize
+                );
+                meta1
+            }
+            (false, true) => {
+                assert_eq!(
+                    meta2.pagesize as u64, self.pagesize,
+                    "Invalid pagesize from meta2 {}. Expected {}.",
+                    meta2.pagesize, self.pagesize
+                );
+                meta2
+            }
+            (false, false) => panic!("NO VALID META PAGES"),
+        }
+        .clone()
+    }
 }
 
 fn init_file(path: &Path, pagesize: u64, num_pages: usize) -> Result<File> {
-	let mut file = FileOpenOptions::new()
-		.create(true)
-		.read(true)
-		.write(true)
-		.open(path)?;
-	file.allocate(pagesize * (num_pages as u64))?;
-	let mut buf = vec![0; (pagesize * 4) as usize];
-	let mut get_page = |index: u64| {
-		#[allow(clippy::cast_ptr_alignment)]
-		unsafe {
-			&mut *(&mut buf[(index * pagesize) as usize] as *mut u8 as *mut Page)
-		}
-	};
-	for i in 0..2 {
-		let page = get_page(i);
-		page.id = i;
-		page.page_type = Page::TYPE_META;
-		let m = page.meta_mut();
-		m.meta_page = i as u8;
-		m.magic = MAGIC_VALUE;
-		m.version = VERSION;
-		m.pagesize = pagesize as u32;
-		m.freelist_page = 2;
-		m.root = BucketMeta {
-			root_page: 3,
-			next_int: 0,
-		};
-		m.num_pages = 4;
-		m.hash = m.hash_self();
-	}
+    let mut file = FileOpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(path)?;
+    file.allocate(pagesize * (num_pages as u64))?;
+    let mut buf = vec![0; (pagesize * 4) as usize];
+    let mut get_page = |index: u64| {
+        #[allow(clippy::cast_ptr_alignment)]
+        unsafe {
+            &mut *(&mut buf[(index * pagesize) as usize] as *mut u8 as *mut Page)
+        }
+    };
+    for i in 0..2 {
+        let page = get_page(i);
+        page.id = i;
+        page.page_type = Page::TYPE_META;
+        let m = page.meta_mut();
+        m.meta_page = i as u8;
+        m.magic = MAGIC_VALUE;
+        m.version = VERSION;
+        m.pagesize = pagesize as u32;
+        m.freelist_page = 2;
+        m.root = BucketMeta {
+            root_page: 3,
+            next_int: 0,
+        };
+        m.num_pages = 4;
+        m.hash = m.hash_self();
+    }
 
-	let p = get_page(2);
-	p.id = 2;
-	p.page_type = Page::TYPE_FREELIST;
-	p.count = 0;
+    let p = get_page(2);
+    p.id = 2;
+    p.page_type = Page::TYPE_FREELIST;
+    p.count = 0;
 
-	let p = get_page(3);
-	p.id = 3;
-	p.page_type = Page::TYPE_LEAF;
-	p.count = 0;
+    let p = get_page(3);
+    p.id = 3;
+    p.page_type = Page::TYPE_LEAF;
+    p.count = 0;
 
-	file.write_all(&buf[..])?;
-	file.flush()?;
-	file.sync_all()?;
-	Ok(file)
+    file.write_all(&buf[..])?;
+    file.flush()?;
+    file.sync_all()?;
+    Ok(file)
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use crate::testutil::RandomFile;
+    use super::*;
+    use crate::testutil::RandomFile;
 
-	#[test]
-	fn test_open_options() {
-		assert_ne!(getPageSize(), 5000);
-		let random_file = RandomFile::new();
-		{
-			let db = OpenOptions::new()
-				.pagesize(5000)
-				.num_pages(100)
-				.open(&random_file)
-				.unwrap();
-			assert_eq!(db.pagesize(), 5000);
-		}
-		{
-			let metadata = random_file.path.metadata().unwrap();
-			assert!(metadata.is_file());
-			assert_eq!(metadata.len(), 500_000);
-		}
-		{
-			let db = OpenOptions::new()
-				.pagesize(5000)
-				.num_pages(100)
-				.open(&random_file)
-				.unwrap();
-			assert_eq!(db.pagesize(), 5000);
-		}
-	}
+    #[test]
+    fn test_open_options() {
+        assert_ne!(getPageSize(), 5000);
+        let random_file = RandomFile::new();
+        {
+            let db = OpenOptions::new()
+                .pagesize(5000)
+                .num_pages(100)
+                .open(&random_file)
+                .unwrap();
+            assert_eq!(db.pagesize(), 5000);
+        }
+        {
+            let metadata = random_file.path.metadata().unwrap();
+            assert!(metadata.is_file());
+            assert_eq!(metadata.len(), 500_000);
+        }
+        {
+            let db = OpenOptions::new()
+                .pagesize(5000)
+                .num_pages(100)
+                .open(&random_file)
+                .unwrap();
+            assert_eq!(db.pagesize(), 5000);
+        }
+    }
 
-	#[test]
-	#[should_panic]
-	fn test_open_options_min_pages() {
-		OpenOptions::new().num_pages(3);
-	}
+    #[test]
+    #[should_panic]
+    fn test_open_options_min_pages() {
+        OpenOptions::new().num_pages(3);
+    }
 
-	#[test]
-	#[should_panic]
-	fn test_open_options_min_pagesize() {
-		OpenOptions::new().pagesize(1000);
-	}
+    #[test]
+    #[should_panic]
+    fn test_open_options_min_pagesize() {
+        OpenOptions::new().pagesize(1000);
+    }
 
-	#[test]
-	#[should_panic]
-	fn test_different_pagesizes() {
-		assert_ne!(getPageSize(), 5000);
-		let random_file = RandomFile::new();
-		{
-			let db = OpenOptions::new()
-				.pagesize(5000)
-				.num_pages(100)
-				.open(&random_file)
-				.unwrap();
-			assert_eq!(db.pagesize(), 5000);
-		}
-		DB::open(&random_file).unwrap();
-	}
+    #[test]
+    #[should_panic]
+    fn test_different_pagesizes() {
+        assert_ne!(getPageSize(), 5000);
+        let random_file = RandomFile::new();
+        {
+            let db = OpenOptions::new()
+                .pagesize(5000)
+                .num_pages(100)
+                .open(&random_file)
+                .unwrap();
+            assert_eq!(db.pagesize(), 5000);
+        }
+        DB::open(&random_file).unwrap();
+    }
 }

--- a/src/freelist.rs
+++ b/src/freelist.rs
@@ -5,197 +5,197 @@ use crate::page::{Page, PageID};
 
 #[derive(Clone)]
 pub(crate) struct Freelist {
-	free_pages: BTreeSet<PageID>,
-	pending_pages: BTreeMap<u64, Vec<PageID>>,
+    free_pages: BTreeSet<PageID>,
+    pending_pages: BTreeMap<u64, Vec<PageID>>,
 }
 
 const HEADER_SIZE: u64 = size_of::<Page>() as u64;
 const PAGE_ID_SIZE: u64 = size_of::<PageID>() as u64;
 
 impl Freelist {
-	pub(crate) fn new() -> Freelist {
-		Freelist {
-			free_pages: BTreeSet::new(),
-			pending_pages: BTreeMap::new(),
-		}
-	}
+    pub(crate) fn new() -> Freelist {
+        Freelist {
+            free_pages: BTreeSet::new(),
+            pending_pages: BTreeMap::new(),
+        }
+    }
 
-	pub(crate) fn init(&mut self, free_pages: &[PageID]) {
-		free_pages.iter().for_each(|id| {
-			self.free_pages.insert(*id);
-		});
-	}
+    pub(crate) fn init(&mut self, free_pages: &[PageID]) {
+        free_pages.iter().for_each(|id| {
+            self.free_pages.insert(*id);
+        });
+    }
 
-	// adds the page to the transaction's set of free pages
-	pub(crate) fn free(&mut self, tx_id: u64, page_id: PageID) {
-		let pages = self.pending_pages.entry(tx_id).or_insert_with(Vec::new);
-		pages.push(page_id);
-	}
+    // adds the page to the transaction's set of free pages
+    pub(crate) fn free(&mut self, tx_id: u64, page_id: PageID) {
+        let pages = self.pending_pages.entry(tx_id).or_insert_with(Vec::new);
+        pages.push(page_id);
+    }
 
-	// frees all pages from old transactions that have lower ids than the given tx_id
-	pub(crate) fn release(&mut self, tx_id: u64) {
-		let pending_ids: Vec<u64> = self.pending_pages.keys().cloned().collect();
-		for other_tx_id in pending_ids {
-			if other_tx_id < tx_id {
-				let pages = self.pending_pages.remove(&other_tx_id).unwrap();
-				pages.into_iter().for_each(|p| {
-					self.free_pages.insert(p);
-				});
-			} else {
-				break;
-			}
-		}
-	}
+    // frees all pages from old transactions that have lower ids than the given tx_id
+    pub(crate) fn release(&mut self, tx_id: u64) {
+        let pending_ids: Vec<u64> = self.pending_pages.keys().cloned().collect();
+        for other_tx_id in pending_ids {
+            if other_tx_id < tx_id {
+                let pages = self.pending_pages.remove(&other_tx_id).unwrap();
+                pages.into_iter().for_each(|p| {
+                    self.free_pages.insert(p);
+                });
+            } else {
+                break;
+            }
+        }
+    }
 
-	pub(crate) fn allocate(&mut self, num_pages: usize) -> Option<PageID> {
-		if self.free_pages.is_empty() {
-			return None;
-		}
-		let mut start: PageID = 0;
-		let mut prev: PageID = 0;
-		let mut found: PageID = 0;
+    pub(crate) fn allocate(&mut self, num_pages: usize) -> Option<PageID> {
+        if self.free_pages.is_empty() {
+            return None;
+        }
+        let mut start: PageID = 0;
+        let mut prev: PageID = 0;
+        let mut found: PageID = 0;
 
-		for id in self.free_pages.iter().cloned() {
-			debug_assert!(id > 1, "invalid pageID in freelist");
+        for id in self.free_pages.iter().cloned() {
+            debug_assert!(id > 1, "invalid pageID in freelist");
 
-			if prev == 0 || id - prev != 1 {
-				start = id;
-			}
+            if prev == 0 || id - prev != 1 {
+                start = id;
+            }
 
-			let block_size = id - start + 1;
-			if block_size == (num_pages as u64) {
-				found = start;
-				break;
-			}
+            let block_size = id - start + 1;
+            if block_size == (num_pages as u64) {
+                found = start;
+                break;
+            }
 
-			prev = id;
-		}
+            prev = id;
+        }
 
-		if found > 0 {
-			for id in found..found + (num_pages as u64) {
-				self.free_pages.remove(&id);
-			}
-			return Some(found);
-		}
+        if found > 0 {
+            for id in found..found + (num_pages as u64) {
+                self.free_pages.remove(&id);
+            }
+            return Some(found);
+        }
 
-		None
-	}
+        None
+    }
 
-	pub(crate) fn pages(&self) -> Vec<PageID> {
-		let mut page_ids: Vec<PageID> = self.free_pages.iter().cloned().collect();
-		for (_, pages) in self.pending_pages.iter() {
-			let mut pages = pages.to_vec();
-			page_ids.append(&mut pages);
-		}
-		page_ids.sort_unstable();
-		page_ids
-	}
+    pub(crate) fn pages(&self) -> Vec<PageID> {
+        let mut page_ids: Vec<PageID> = self.free_pages.iter().cloned().collect();
+        for (_, pages) in self.pending_pages.iter() {
+            let mut pages = pages.to_vec();
+            page_ids.append(&mut pages);
+        }
+        page_ids.sort_unstable();
+        page_ids
+    }
 
-	pub(crate) fn size(&self) -> u64 {
-		let count = self.pages().len() as u64;
-		HEADER_SIZE + (PAGE_ID_SIZE * count)
-	}
+    pub(crate) fn size(&self) -> u64 {
+        let count = self.pages().len() as u64;
+        HEADER_SIZE + (PAGE_ID_SIZE * count)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	fn freelist_from_vec(v: Vec<PageID>) -> Freelist {
-		let mut freelist = Freelist {
-			free_pages: v.iter().cloned().collect(),
-			pending_pages: BTreeMap::new(),
-		};
-		freelist.init(v.as_slice());
-		freelist
-	}
+    fn freelist_from_vec(v: Vec<PageID>) -> Freelist {
+        let mut freelist = Freelist {
+            free_pages: v.iter().cloned().collect(),
+            pending_pages: BTreeMap::new(),
+        };
+        freelist.init(v.as_slice());
+        freelist
+    }
 
-	#[test]
-	fn test_allocate() {
-		let mut freelist = freelist_from_vec(vec![2, 4, 6, 8, 9, 10]);
-		assert_eq!(freelist.allocate(4), None);
-		assert_eq!(freelist.allocate(1), Some(2));
-		assert_eq!(
-			freelist.free_pages.iter().cloned().collect::<Vec<u64>>(),
-			vec![4, 6, 8, 9, 10]
-		);
-		assert_eq!(freelist.allocate(1), Some(4));
-		assert_eq!(
-			freelist.free_pages.iter().cloned().collect::<Vec<u64>>(),
-			vec![6, 8, 9, 10]
-		);
-		assert_eq!(freelist.allocate(3), Some(8));
-		assert_eq!(
-			freelist.free_pages.iter().cloned().collect::<Vec<u64>>(),
-			vec![6]
-		);
-		assert_eq!(freelist.allocate(1), Some(6));
-		assert_eq!(
-			freelist.free_pages.iter().cloned().collect::<Vec<u64>>(),
-			vec![]
-		);
-		assert_eq!(freelist.allocate(1), None);
-	}
+    #[test]
+    fn test_allocate() {
+        let mut freelist = freelist_from_vec(vec![2, 4, 6, 8, 9, 10]);
+        assert_eq!(freelist.allocate(4), None);
+        assert_eq!(freelist.allocate(1), Some(2));
+        assert_eq!(
+            freelist.free_pages.iter().cloned().collect::<Vec<u64>>(),
+            vec![4, 6, 8, 9, 10]
+        );
+        assert_eq!(freelist.allocate(1), Some(4));
+        assert_eq!(
+            freelist.free_pages.iter().cloned().collect::<Vec<u64>>(),
+            vec![6, 8, 9, 10]
+        );
+        assert_eq!(freelist.allocate(3), Some(8));
+        assert_eq!(
+            freelist.free_pages.iter().cloned().collect::<Vec<u64>>(),
+            vec![6]
+        );
+        assert_eq!(freelist.allocate(1), Some(6));
+        assert_eq!(
+            freelist.free_pages.iter().cloned().collect::<Vec<u64>>(),
+            vec![]
+        );
+        assert_eq!(freelist.allocate(1), None);
+    }
 
-	#[test]
-	fn test_free() {
-		let mut freelist = Freelist::new();
+    #[test]
+    fn test_free() {
+        let mut freelist = Freelist::new();
 
-		freelist.free(1, 5);
-		assert_eq!(freelist.pending_pages.len(), 1);
-		assert_eq!(freelist.pending_pages.get(&1), Some(&vec![5]));
-		freelist.free(1, 4);
-		assert_eq!(freelist.pending_pages.len(), 1);
-		assert_eq!(freelist.pending_pages.get(&1), Some(&vec![5, 4]));
-		freelist.free(1, 3);
-		assert_eq!(freelist.pending_pages.len(), 1);
-		assert_eq!(freelist.pending_pages.get(&1), Some(&vec![5, 4, 3]));
-		freelist.free(2, 7);
-		assert_eq!(freelist.pending_pages.len(), 2);
-		assert_eq!(freelist.pending_pages.get(&1), Some(&vec![5, 4, 3]));
-		assert_eq!(freelist.pending_pages.get(&2), Some(&vec![7]));
-		assert_eq!(freelist.free_pages, BTreeSet::new());
-	}
+        freelist.free(1, 5);
+        assert_eq!(freelist.pending_pages.len(), 1);
+        assert_eq!(freelist.pending_pages.get(&1), Some(&vec![5]));
+        freelist.free(1, 4);
+        assert_eq!(freelist.pending_pages.len(), 1);
+        assert_eq!(freelist.pending_pages.get(&1), Some(&vec![5, 4]));
+        freelist.free(1, 3);
+        assert_eq!(freelist.pending_pages.len(), 1);
+        assert_eq!(freelist.pending_pages.get(&1), Some(&vec![5, 4, 3]));
+        freelist.free(2, 7);
+        assert_eq!(freelist.pending_pages.len(), 2);
+        assert_eq!(freelist.pending_pages.get(&1), Some(&vec![5, 4, 3]));
+        assert_eq!(freelist.pending_pages.get(&2), Some(&vec![7]));
+        assert_eq!(freelist.free_pages, BTreeSet::new());
+    }
 
-	#[test]
-	fn test_pages() {
-		let mut freelist = freelist_from_vec(vec![1, 2, 3, 4, 5]);
+    #[test]
+    fn test_pages() {
+        let mut freelist = freelist_from_vec(vec![1, 2, 3, 4, 5]);
 
-		assert_eq!(freelist.pages(), vec![1, 2, 3, 4, 5]);
-		freelist.free(2, 9);
-		freelist.free(2, 10);
-		freelist.free(2, 11);
-		assert_eq!(freelist.pages(), vec![1, 2, 3, 4, 5, 9, 10, 11]);
+        assert_eq!(freelist.pages(), vec![1, 2, 3, 4, 5]);
+        freelist.free(2, 9);
+        freelist.free(2, 10);
+        freelist.free(2, 11);
+        assert_eq!(freelist.pages(), vec![1, 2, 3, 4, 5, 9, 10, 11]);
 
-		freelist.free(1, 6);
-		freelist.free(1, 7);
-		freelist.free(1, 8);
-		assert_eq!(freelist.pages(), vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
-	}
+        freelist.free(1, 6);
+        freelist.free(1, 7);
+        freelist.free(1, 8);
+        assert_eq!(freelist.pages(), vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+    }
 
-	#[test]
-	fn test_release() {
-		let mut freelist = Freelist::new();
+    #[test]
+    fn test_release() {
+        let mut freelist = Freelist::new();
 
-		freelist.free(1, 5);
-		freelist.free(1, 10);
-		freelist.free(1, 7);
+        freelist.free(1, 5);
+        freelist.free(1, 10);
+        freelist.free(1, 7);
 
-		assert_eq!(freelist.free_pages.len(), 0);
-		assert_eq!(freelist.pending_pages.len(), 1);
-		freelist.release(1);
-		assert_eq!(freelist.free_pages.len(), 0);
-		assert_eq!(freelist.pending_pages.len(), 1);
+        assert_eq!(freelist.free_pages.len(), 0);
+        assert_eq!(freelist.pending_pages.len(), 1);
+        freelist.release(1);
+        assert_eq!(freelist.free_pages.len(), 0);
+        assert_eq!(freelist.pending_pages.len(), 1);
 
-		freelist.release(2);
-		assert_eq!(freelist.free_pages.len(), 3);
-		assert_eq!(freelist.pending_pages.len(), 0);
-		assert_eq!(freelist.pages(), vec![5, 7, 10]);
-	}
+        freelist.release(2);
+        assert_eq!(freelist.free_pages.len(), 3);
+        assert_eq!(freelist.pending_pages.len(), 0);
+        assert_eq!(freelist.pages(), vec![5, 7, 10]);
+    }
 
-	#[test]
-	fn test_size() {
-		let freelist = freelist_from_vec(vec![1, 2, 3]);
-		assert_eq!(freelist.size(), HEADER_SIZE + (PAGE_ID_SIZE * 3));
-	}
+    #[test]
+    fn test_size() {
+        let freelist = freelist_from_vec(vec![1, 2, 3]);
+        assert_eq!(freelist.size(), HEADER_SIZE + (PAGE_ID_SIZE * 3));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,42 +136,42 @@ pub use transaction::Transaction;
 
 #[cfg(test)]
 mod testutil {
-	use rand::{distributions::Alphanumeric, Rng};
+    use rand::{distributions::Alphanumeric, Rng};
 
-	pub struct RandomFile {
-		pub path: std::path::PathBuf,
-	}
+    pub struct RandomFile {
+        pub path: std::path::PathBuf,
+    }
 
-	impl RandomFile {
-		pub fn new() -> RandomFile {
-			loop {
-				let filename: String = std::str::from_utf8(
-					rand::thread_rng()
-						.sample_iter(&Alphanumeric)
-						.take(30)
-						.collect::<Vec<u8>>()
-						.as_slice(),
-				)
-				.unwrap()
-				.into();
-				let path = std::env::temp_dir().join(filename);
-				if path.metadata().is_err() {
-					return RandomFile { path };
-				}
-			}
-		}
-	}
+    impl RandomFile {
+        pub fn new() -> RandomFile {
+            loop {
+                let filename: String = std::str::from_utf8(
+                    rand::thread_rng()
+                        .sample_iter(&Alphanumeric)
+                        .take(30)
+                        .collect::<Vec<u8>>()
+                        .as_slice(),
+                )
+                .unwrap()
+                .into();
+                let path = std::env::temp_dir().join(filename);
+                if path.metadata().is_err() {
+                    return RandomFile { path };
+                }
+            }
+        }
+    }
 
-	impl AsRef<std::path::Path> for RandomFile {
-		fn as_ref(&self) -> &std::path::Path {
-			self.path.as_ref()
-		}
-	}
+    impl AsRef<std::path::Path> for RandomFile {
+        fn as_ref(&self) -> &std::path::Path {
+            self.path.as_ref()
+        }
+    }
 
-	impl Drop for RandomFile {
-		#[allow(unused_must_use)]
-		fn drop(&mut self) {
-			std::fs::remove_file(&self.path);
-		}
-	}
+    impl Drop for RandomFile {
+        #[allow(unused_must_use)]
+        fn drop(&mut self) {
+            std::fs::remove_file(&self.path);
+        }
+    }
 }

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -10,69 +10,69 @@ const META_SIZE: usize = size_of::<Meta>();
 #[repr(C)]
 #[derive(Debug, Clone)]
 pub(crate) struct Meta {
-	pub(crate) meta_page: u8,
-	pub(crate) magic: u32,
-	pub(crate) version: u32,
-	pub(crate) pagesize: u32,
-	pub(crate) root: BucketMeta,
-	pub(crate) num_pages: PageID,
-	pub(crate) freelist_page: PageID,
-	pub(crate) tx_id: u64,
-	pub(crate) hash: [u8; 32],
+    pub(crate) meta_page: u8,
+    pub(crate) magic: u32,
+    pub(crate) version: u32,
+    pub(crate) pagesize: u32,
+    pub(crate) root: BucketMeta,
+    pub(crate) num_pages: PageID,
+    pub(crate) freelist_page: PageID,
+    pub(crate) tx_id: u64,
+    pub(crate) hash: [u8; 32],
 }
 
 impl Meta {
-	pub(crate) fn valid(&self) -> bool {
-		self.hash == self.hash_self()
-	}
+    pub(crate) fn valid(&self) -> bool {
+        self.hash == self.hash_self()
+    }
 
-	pub(crate) fn hash_self(&self) -> [u8; 32] {
-		let mut hash_result: [u8; 32] = [0; 32];
-		let mut hasher = Sha3_256::new();
-		hasher.update(self.bytes());
-		let hash = hasher.finalize();
-		hash_result.copy_from_slice(&hash[..]);
-		hash_result
-	}
+    pub(crate) fn hash_self(&self) -> [u8; 32] {
+        let mut hash_result: [u8; 32] = [0; 32];
+        let mut hasher = Sha3_256::new();
+        hasher.update(self.bytes());
+        let hash = hasher.finalize();
+        hash_result.copy_from_slice(&hash[..]);
+        hash_result
+    }
 
-	fn bytes(&self) -> &[u8] {
-		let ptr = self as *const Meta as *const u8;
-		unsafe { std::slice::from_raw_parts(ptr, META_SIZE - 32) }
-	}
+    fn bytes(&self) -> &[u8] {
+        let ptr = self as *const Meta as *const u8;
+        unsafe { std::slice::from_raw_parts(ptr, META_SIZE - 32) }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn test_meta() {
-		let mut meta = Meta {
-			meta_page: 1,
-			magic: 1_234_567_890,
-			version: 987_654_321,
-			pagesize: 4096,
-			root: BucketMeta {
-				root_page: 2,
-				next_int: 2020,
-			},
-			num_pages: 13,
-			freelist_page: 3,
-			tx_id: 8,
-			hash: [0; 32],
-		};
+    #[test]
+    fn test_meta() {
+        let mut meta = Meta {
+            meta_page: 1,
+            magic: 1_234_567_890,
+            version: 987_654_321,
+            pagesize: 4096,
+            root: BucketMeta {
+                root_page: 2,
+                next_int: 2020,
+            },
+            num_pages: 13,
+            freelist_page: 3,
+            tx_id: 8,
+            hash: [0; 32],
+        };
 
-		assert!(!meta.valid());
-		meta.hash = meta.hash_self();
-		assert!(meta.valid());
-		assert_eq!(meta.hash, meta.hash_self());
-		// modify the last property before the hash
-		// to change the hash
-		meta.tx_id = 88;
-		assert_ne!(meta.hash, meta.hash_self());
-		// reset hash and make sure it is still valid
-		meta.hash = meta.hash_self();
-		assert!(meta.valid());
-		assert_eq!(meta.hash, meta.hash_self());
-	}
+        assert!(!meta.valid());
+        meta.hash = meta.hash_self();
+        assert!(meta.valid());
+        assert_eq!(meta.hash, meta.hash_self());
+        // modify the last property before the hash
+        // to change the hash
+        meta.tx_id = 88;
+        assert_ne!(meta.hash, meta.hash_self());
+        // reset hash and make sure it is still valid
+        meta.hash = meta.hash_self();
+        assert!(meta.valid());
+        assert_eq!(meta.hash, meta.hash_self());
+    }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -18,385 +18,385 @@ const MIN_KEYS_PER_NODE: usize = 2;
 const FILL_PERCENT: f32 = 0.5;
 
 pub(crate) struct Node {
-	pub(crate) id: NodeID,
-	pub(crate) page_id: PageID,
-	pub(crate) num_pages: u64,
-	bucket: Ptr<BucketInner>,
-	// pub (crate) key: SliceParts,
-	pub(crate) children: Vec<NodeID>,
-	pub(crate) data: NodeData,
-	pub(crate) deleted: bool,
-	original_key: Option<SliceParts>,
+    pub(crate) id: NodeID,
+    pub(crate) page_id: PageID,
+    pub(crate) num_pages: u64,
+    bucket: Ptr<BucketInner>,
+    // pub (crate) key: SliceParts,
+    pub(crate) children: Vec<NodeID>,
+    pub(crate) data: NodeData,
+    pub(crate) deleted: bool,
+    original_key: Option<SliceParts>,
 }
 
 pub(crate) enum NodeData {
-	Branches(Vec<Branch>),
-	Leaves(Vec<Data>),
+    Branches(Vec<Branch>),
+    Leaves(Vec<Data>),
 }
 
 impl NodeData {
-	pub(crate) fn len(&self) -> usize {
-		match self {
-			NodeData::Branches(b) => b.len(),
-			NodeData::Leaves(l) => l.len(),
-		}
-	}
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            NodeData::Branches(b) => b.len(),
+            NodeData::Leaves(l) => l.len(),
+        }
+    }
 
-	fn size(&self) -> u64 {
-		match self {
-			NodeData::Branches(b) => b
-				.iter()
-				.fold(BRANCH_SIZE * b.len() as u64, |acc, b| acc + b.key_size()),
-			NodeData::Leaves(l) => l
-				.iter()
-				.fold(LEAF_SIZE * l.len() as u64, |acc, l| acc + l.size()),
-		}
-	}
+    fn size(&self) -> u64 {
+        match self {
+            NodeData::Branches(b) => b
+                .iter()
+                .fold(BRANCH_SIZE * b.len() as u64, |acc, b| acc + b.key_size()),
+            NodeData::Leaves(l) => l
+                .iter()
+                .fold(LEAF_SIZE * l.len() as u64, |acc, l| acc + l.size()),
+        }
+    }
 
-	pub(crate) fn key_parts(&self) -> SliceParts {
-		debug_assert!(self.len() > 0, "Cannot get key parts of empty data");
-		match self {
-			NodeData::Branches(b) => b.first().map(|b| b.key),
-			NodeData::Leaves(l) => l.first().map(|l| l.key_parts()),
-		}
-		.unwrap()
-	}
+    pub(crate) fn key_parts(&self) -> SliceParts {
+        debug_assert!(self.len() > 0, "Cannot get key parts of empty data");
+        match self {
+            NodeData::Branches(b) => b.first().map(|b| b.key),
+            NodeData::Leaves(l) => l.first().map(|l| l.key_parts()),
+        }
+        .unwrap()
+    }
 
-	fn split_at(&mut self, index: usize) -> NodeData {
-		match self {
-			NodeData::Branches(b) => NodeData::Branches(b.split_off(index)),
-			NodeData::Leaves(l) => NodeData::Leaves(l.split_off(index)),
-		}
-	}
+    fn split_at(&mut self, index: usize) -> NodeData {
+        match self {
+            NodeData::Branches(b) => NodeData::Branches(b.split_off(index)),
+            NodeData::Leaves(l) => NodeData::Leaves(l.split_off(index)),
+        }
+    }
 
-	fn merge(&mut self, other_data: &mut Self) {
-		match (self, other_data) {
-			(NodeData::Branches(b1), NodeData::Branches(b2)) => {
-				b1.append(b2);
-				b1.sort_unstable_by_key(|b| b.key);
-			}
-			(NodeData::Leaves(l1), NodeData::Leaves(l2)) => {
-				l1.append(l2);
-				l1.sort_unstable_by_key(|l| l.key_parts());
-			}
-			_ => panic!("incompatible data types"),
-		}
-	}
+    fn merge(&mut self, other_data: &mut Self) {
+        match (self, other_data) {
+            (NodeData::Branches(b1), NodeData::Branches(b2)) => {
+                b1.append(b2);
+                b1.sort_unstable_by_key(|b| b.key);
+            }
+            (NodeData::Leaves(l1), NodeData::Leaves(l2)) => {
+                l1.append(l2);
+                l1.sort_unstable_by_key(|l| l.key_parts());
+            }
+            _ => panic!("incompatible data types"),
+        }
+    }
 }
 
 pub(crate) struct Branch {
-	key: SliceParts,
-	pub(crate) page: PageID,
+    key: SliceParts,
+    pub(crate) page: PageID,
 }
 
 impl Branch {
-	pub(crate) fn from_node(node: &Node) -> Branch {
-		Branch {
-			key: node.data.key_parts(),
-			page: node.page_id,
-		}
-	}
+    pub(crate) fn from_node(node: &Node) -> Branch {
+        Branch {
+            key: node.data.key_parts(),
+            page: node.page_id,
+        }
+    }
 
-	pub(crate) fn key(&self) -> &[u8] {
-		self.key.slice()
-	}
+    pub(crate) fn key(&self) -> &[u8] {
+        self.key.slice()
+    }
 
-	pub(crate) fn key_size(&self) -> u64 {
-		self.key.size()
-	}
+    pub(crate) fn key_size(&self) -> u64 {
+        self.key.size()
+    }
 }
 
 // Change to DataType
 pub(crate) type NodeType = u8;
 
 impl Node {
-	pub(crate) const TYPE_DATA: NodeType = 0x00;
-	pub(crate) const TYPE_BUCKET: NodeType = 0x01;
+    pub(crate) const TYPE_DATA: NodeType = 0x00;
+    pub(crate) const TYPE_BUCKET: NodeType = 0x01;
 
-	pub(crate) fn new(id: NodeID, t: PageType, b: Ptr<BucketInner>) -> Node {
-		let data: NodeData = match t {
-			Page::TYPE_BRANCH => NodeData::Branches(Vec::new()),
-			Page::TYPE_LEAF => NodeData::Leaves(Vec::new()),
-			_ => panic!("INVALID PAGE TYPE FOR NEW NODE"),
-		};
-		Node {
-			id,
-			page_id: 0,
-			num_pages: 0,
-			bucket: b,
-			children: Vec::new(),
-			data,
-			deleted: false,
-			original_key: None,
-		}
-	}
+    pub(crate) fn new(id: NodeID, t: PageType, b: Ptr<BucketInner>) -> Node {
+        let data: NodeData = match t {
+            Page::TYPE_BRANCH => NodeData::Branches(Vec::new()),
+            Page::TYPE_LEAF => NodeData::Leaves(Vec::new()),
+            _ => panic!("INVALID PAGE TYPE FOR NEW NODE"),
+        };
+        Node {
+            id,
+            page_id: 0,
+            num_pages: 0,
+            bucket: b,
+            children: Vec::new(),
+            data,
+            deleted: false,
+            original_key: None,
+        }
+    }
 
-	pub(crate) fn with_data(id: NodeID, data: NodeData, b: Ptr<BucketInner>) -> Node {
-		let original_key = Some(data.key_parts());
-		Node {
-			id,
-			page_id: 0,
-			num_pages: 0,
-			bucket: b,
-			children: Vec::new(),
-			data,
-			deleted: false,
-			original_key,
-		}
-	}
+    pub(crate) fn with_data(id: NodeID, data: NodeData, b: Ptr<BucketInner>) -> Node {
+        let original_key = Some(data.key_parts());
+        Node {
+            id,
+            page_id: 0,
+            num_pages: 0,
+            bucket: b,
+            children: Vec::new(),
+            data,
+            deleted: false,
+            original_key,
+        }
+    }
 
-	pub(crate) fn from_page(id: NodeID, b: Ptr<BucketInner>, p: &Page) -> Node {
-		let data: NodeData = match p.page_type {
-			Page::TYPE_BRANCH => {
-				let mut data = Vec::with_capacity(p.count as usize);
-				for branch in p.branch_elements() {
-					data.push(Branch {
-						key: SliceParts::from_slice(branch.key()),
-						page: branch.page,
-					});
-				}
-				NodeData::Branches(data)
-			}
-			Page::TYPE_LEAF => {
-				let mut data = Vec::with_capacity(p.count as usize);
-				for leaf in p.leaf_elements() {
-					data.push(Data::from_leaf(leaf));
-				}
-				NodeData::Leaves(data)
-			}
-			_ => panic!("INVALID PAGE TYPE FOR FROM_PAGE"),
-		};
-		let original_key = if data.len() > 0 {
-			Some(data.key_parts())
-		} else {
-			None
-		};
-		Node {
-			id,
-			page_id: p.id,
-			num_pages: p.overflow + 1,
-			bucket: b,
-			children: Vec::new(),
-			data,
-			deleted: false,
-			original_key,
-		}
-	}
+    pub(crate) fn from_page(id: NodeID, b: Ptr<BucketInner>, p: &Page) -> Node {
+        let data: NodeData = match p.page_type {
+            Page::TYPE_BRANCH => {
+                let mut data = Vec::with_capacity(p.count as usize);
+                for branch in p.branch_elements() {
+                    data.push(Branch {
+                        key: SliceParts::from_slice(branch.key()),
+                        page: branch.page,
+                    });
+                }
+                NodeData::Branches(data)
+            }
+            Page::TYPE_LEAF => {
+                let mut data = Vec::with_capacity(p.count as usize);
+                for leaf in p.leaf_elements() {
+                    data.push(Data::from_leaf(leaf));
+                }
+                NodeData::Leaves(data)
+            }
+            _ => panic!("INVALID PAGE TYPE FOR FROM_PAGE"),
+        };
+        let original_key = if data.len() > 0 {
+            Some(data.key_parts())
+        } else {
+            None
+        };
+        Node {
+            id,
+            page_id: p.id,
+            num_pages: p.overflow + 1,
+            bucket: b,
+            children: Vec::new(),
+            data,
+            deleted: false,
+            original_key,
+        }
+    }
 
-	pub(crate) fn leaf(&self) -> bool {
-		match &self.data {
-			NodeData::Branches(_) => false,
-			NodeData::Leaves(_) => true,
-		}
-	}
+    pub(crate) fn leaf(&self) -> bool {
+        match &self.data {
+            NodeData::Branches(_) => false,
+            NodeData::Leaves(_) => true,
+        }
+    }
 
-	pub(crate) fn insert_data(&mut self, data: Data) {
-		match &mut self.data {
-			NodeData::Branches(_) => panic!("CANNOT INSERT DATA INTO A BRANCH NODE"),
-			NodeData::Leaves(leaves) => {
-				match leaves.binary_search_by_key(&data.key(), |d| &d.key()) {
-					Ok(i) => leaves[i] = data,
-					Err(i) => leaves.insert(i, data),
-				};
-			}
-		}
-	}
+    pub(crate) fn insert_data(&mut self, data: Data) {
+        match &mut self.data {
+            NodeData::Branches(_) => panic!("CANNOT INSERT DATA INTO A BRANCH NODE"),
+            NodeData::Leaves(leaves) => {
+                match leaves.binary_search_by_key(&data.key(), |d| &d.key()) {
+                    Ok(i) => leaves[i] = data,
+                    Err(i) => leaves.insert(i, data),
+                };
+            }
+        }
+    }
 
-	pub(crate) fn insert_child(&mut self, id: NodeID, key: SliceParts) {
-		match &mut self.data {
-			NodeData::Branches(branches) => {
-				debug_assert!(!self.children.contains(&id));
-				debug_assert!(branches
-					.binary_search_by_key(&key.slice(), |b| &b.key())
-					.is_ok());
-				self.children.push(id);
-			}
-			NodeData::Leaves(_) => panic!("CANNOT INSERT BRANCH INTO A LEAF NODE"),
-		}
-	}
+    pub(crate) fn insert_child(&mut self, id: NodeID, key: SliceParts) {
+        match &mut self.data {
+            NodeData::Branches(branches) => {
+                debug_assert!(!self.children.contains(&id));
+                debug_assert!(branches
+                    .binary_search_by_key(&key.slice(), |b| &b.key())
+                    .is_ok());
+                self.children.push(id);
+            }
+            NodeData::Leaves(_) => panic!("CANNOT INSERT BRANCH INTO A LEAF NODE"),
+        }
+    }
 
-	pub(crate) fn delete(&mut self, index: usize) -> Data {
-		match &mut self.data {
-			NodeData::Branches(_) => panic!("CANNOT DELETE DATA FROM A BRANCH NODE"),
-			NodeData::Leaves(leaves) => leaves.remove(index),
-		}
-	}
+    pub(crate) fn delete(&mut self, index: usize) -> Data {
+        match &mut self.data {
+            NodeData::Branches(_) => panic!("CANNOT DELETE DATA FROM A BRANCH NODE"),
+            NodeData::Leaves(leaves) => leaves.remove(index),
+        }
+    }
 
-	fn size(&self) -> u64 {
-		HEADER_SIZE + self.data.size()
-	}
+    fn size(&self) -> u64 {
+        HEADER_SIZE + self.data.size()
+    }
 
-	pub(crate) fn write(&mut self, file: &mut File) -> Result<()> {
-		if self.deleted {
-			return Ok(());
-		}
-		let size = self.size();
-		let mut buf: Vec<u8> = vec![0; size as usize];
-		#[allow(clippy::cast_ptr_alignment)]
-		let page = unsafe { &mut *(&mut buf[0] as *mut u8 as *mut Page) };
-		page.write_node(self, self.num_pages)?;
-		let offset = (self.page_id as u64) * (self.bucket.tx.meta.pagesize as u64);
-		file.seek(SeekFrom::Start(offset))?;
-		file.write_all(buf.as_slice())?;
-		Ok(())
-	}
+    pub(crate) fn write(&mut self, file: &mut File) -> Result<()> {
+        if self.deleted {
+            return Ok(());
+        }
+        let size = self.size();
+        let mut buf: Vec<u8> = vec![0; size as usize];
+        #[allow(clippy::cast_ptr_alignment)]
+        let page = unsafe { &mut *(&mut buf[0] as *mut u8 as *mut Page) };
+        page.write_node(self, self.num_pages)?;
+        let offset = (self.page_id as u64) * (self.bucket.tx.meta.pagesize as u64);
+        file.seek(SeekFrom::Start(offset))?;
+        file.write_all(buf.as_slice())?;
+        Ok(())
+    }
 
-	pub(crate) fn merge(&mut self) -> bool {
-		// merge children if it is a branch node
-		if let NodeData::Branches(branches) = &mut self.data {
-			let mut deleted_children = vec![];
-			let mut i = 0;
-			while i < self.children.len() {
-				// stop if there is only one branch left
-				if branches.len() == 1 {
-					break;
-				}
-				let mut b = Ptr::new(&self.bucket);
-				let id = PageNodeID::Node(self.children[i]);
-				let child = self.bucket.node(id);
-				// check if child needs to be merged.
-				if child.merge() {
-					// find the child's branch element in this node's data
-					let index = match branches
-						.binary_search_by_key(&child.original_key.unwrap().slice(), |b| b.key())
-					{
-						Ok(i) => i,
-						_ => panic!("THIS IS VERY VERY BAD"),
-					};
-					// check if there is any data left to copy
-					if child.data.len() > 0 {
-						// add that child's data to a sibling node
-						let sibling_page = if index == 0 {
-							// right sibling
-							branches[index + 1].page
-						} else {
-							// left sibling
-							branches[index - 1].page
-						};
-						let sibling = b.node(PageNodeID::Page(sibling_page));
-						sibling.data.merge(&mut child.data);
-					}
+    pub(crate) fn merge(&mut self) -> bool {
+        // merge children if it is a branch node
+        if let NodeData::Branches(branches) = &mut self.data {
+            let mut deleted_children = vec![];
+            let mut i = 0;
+            while i < self.children.len() {
+                // stop if there is only one branch left
+                if branches.len() == 1 {
+                    break;
+                }
+                let mut b = Ptr::new(&self.bucket);
+                let id = PageNodeID::Node(self.children[i]);
+                let child = self.bucket.node(id);
+                // check if child needs to be merged.
+                if child.merge() {
+                    // find the child's branch element in this node's data
+                    let index = match branches
+                        .binary_search_by_key(&child.original_key.unwrap().slice(), |b| b.key())
+                    {
+                        Ok(i) => i,
+                        _ => panic!("THIS IS VERY VERY BAD"),
+                    };
+                    // check if there is any data left to copy
+                    if child.data.len() > 0 {
+                        // add that child's data to a sibling node
+                        let sibling_page = if index == 0 {
+                            // right sibling
+                            branches[index + 1].page
+                        } else {
+                            // left sibling
+                            branches[index - 1].page
+                        };
+                        let sibling = b.node(PageNodeID::Page(sibling_page));
+                        sibling.data.merge(&mut child.data);
+                    }
 
-					// free the child's page and mark it as deleted
-					child.free_page();
-					child.deleted = true;
+                    // free the child's page and mark it as deleted
+                    child.free_page();
+                    child.deleted = true;
 
-					// remove the child from this node
-					branches.remove(index);
-					deleted_children.push(i);
-				}
-				i += 1;
-			}
-			for c in deleted_children.iter().rev() {
-				self.children.remove(*c);
-			}
-		}
-		// determine if this node needs to be merged, and return the value
-		// needs to be merged if it does not have enough keys, or if it doesn't fill 1/4 of a page
-		self.data.len() < MIN_KEYS_PER_NODE || self.size() < (self.bucket.tx.db.pagesize / 4)
-	}
+                    // remove the child from this node
+                    branches.remove(index);
+                    deleted_children.push(i);
+                }
+                i += 1;
+            }
+            for c in deleted_children.iter().rev() {
+                self.children.remove(*c);
+            }
+        }
+        // determine if this node needs to be merged, and return the value
+        // needs to be merged if it does not have enough keys, or if it doesn't fill 1/4 of a page
+        self.data.len() < MIN_KEYS_PER_NODE || self.size() < (self.bucket.tx.db.pagesize / 4)
+    }
 
-	pub(crate) fn free_page(&mut self) {
-		if self.page_id != 0 {
-			self.bucket.tx.free(self.page_id, self.num_pages);
-			self.page_id = 0;
-		}
-	}
+    pub(crate) fn free_page(&mut self) {
+        if self.page_id != 0 {
+            self.bucket.tx.free(self.page_id, self.num_pages);
+            self.page_id = 0;
+        }
+    }
 
-	fn allocate(&mut self) {
-		self.free_page();
-		let size = self.size();
-		let (page_id, num_pages) = self.bucket.tx.allocate(size);
-		self.page_id = page_id;
-		self.num_pages = num_pages;
-	}
+    fn allocate(&mut self) {
+        self.free_page();
+        let size = self.size();
+        let (page_id, num_pages) = self.bucket.tx.allocate(size);
+        self.page_id = page_id;
+        self.num_pages = num_pages;
+    }
 
-	pub(crate) fn split(&mut self) -> Option<Vec<Branch>> {
-		// sort children so we iterate over them in order
-		let mut b = Ptr::new(&self.bucket);
-		self.children
-			.sort_by_cached_key(|id| b.node(PageNodeID::Node(*id)).data.key_parts());
-		for child in self.children.iter() {
-			let child = self.bucket.node(PageNodeID::Node(*child));
-			let new_branches = child.split();
-			if let NodeData::Branches(branches) = &mut self.data {
-				let index = match branches
-					.binary_search_by_key(&child.original_key.unwrap().slice(), |b| b.key())
-				{
-					Ok(i) => i,
-					_ => panic!("THIS IS VERY VERY BAD"),
-				};
-				branches[index] = Branch::from_node(&child);
-				if let Some(mut new_branches) = new_branches {
-					let mut right_side = branches.split_off(index + 1);
-					branches.append(&mut new_branches);
-					branches.append(&mut right_side);
-				}
-			}
-		}
-		if self.data.len() <= (MIN_KEYS_PER_NODE * 2) || self.size() < self.bucket.tx.db.pagesize {
-			self.allocate();
-			return None;
-		}
-		let threshold = ((self.bucket.tx.db.pagesize as f32) * FILL_PERCENT) as u64;
-		let mut split_indexes = Vec::<usize>::new();
-		let mut current_size = HEADER_SIZE;
-		let mut count = 0;
-		match &self.data {
-			NodeData::Branches(b) => {
-				for (i, b) in b.iter().enumerate() {
-					count += 1;
-					let size = BRANCH_SIZE + b.key_size();
-					let new_size = current_size + size;
-					if count >= MIN_KEYS_PER_NODE && new_size > threshold {
-						split_indexes.push(i);
-						current_size = HEADER_SIZE + size;
-						count = 0;
-					} else {
-						current_size = new_size;
-					}
-				}
-			}
-			NodeData::Leaves(leaves) => {
-				for (i, l) in leaves.iter().enumerate() {
-					count += 1;
-					let size = LEAF_SIZE + l.size();
-					let new_size = current_size + size;
-					if count >= MIN_KEYS_PER_NODE && new_size > threshold {
-						split_indexes.push(i);
-						current_size = HEADER_SIZE + size;
-						count = 0;
-					} else {
-						current_size = new_size;
-					}
-				}
-			}
-		};
-		// for some reason we didn't find a place to split
-		if split_indexes.is_empty() {
-			self.allocate();
-			return None;
-		}
+    pub(crate) fn split(&mut self) -> Option<Vec<Branch>> {
+        // sort children so we iterate over them in order
+        let mut b = Ptr::new(&self.bucket);
+        self.children
+            .sort_by_cached_key(|id| b.node(PageNodeID::Node(*id)).data.key_parts());
+        for child in self.children.iter() {
+            let child = self.bucket.node(PageNodeID::Node(*child));
+            let new_branches = child.split();
+            if let NodeData::Branches(branches) = &mut self.data {
+                let index = match branches
+                    .binary_search_by_key(&child.original_key.unwrap().slice(), |b| b.key())
+                {
+                    Ok(i) => i,
+                    _ => panic!("THIS IS VERY VERY BAD"),
+                };
+                branches[index] = Branch::from_node(&child);
+                if let Some(mut new_branches) = new_branches {
+                    let mut right_side = branches.split_off(index + 1);
+                    branches.append(&mut new_branches);
+                    branches.append(&mut right_side);
+                }
+            }
+        }
+        if self.data.len() <= (MIN_KEYS_PER_NODE * 2) || self.size() < self.bucket.tx.db.pagesize {
+            self.allocate();
+            return None;
+        }
+        let threshold = ((self.bucket.tx.db.pagesize as f32) * FILL_PERCENT) as u64;
+        let mut split_indexes = Vec::<usize>::new();
+        let mut current_size = HEADER_SIZE;
+        let mut count = 0;
+        match &self.data {
+            NodeData::Branches(b) => {
+                for (i, b) in b.iter().enumerate() {
+                    count += 1;
+                    let size = BRANCH_SIZE + b.key_size();
+                    let new_size = current_size + size;
+                    if count >= MIN_KEYS_PER_NODE && new_size > threshold {
+                        split_indexes.push(i);
+                        current_size = HEADER_SIZE + size;
+                        count = 0;
+                    } else {
+                        current_size = new_size;
+                    }
+                }
+            }
+            NodeData::Leaves(leaves) => {
+                for (i, l) in leaves.iter().enumerate() {
+                    count += 1;
+                    let size = LEAF_SIZE + l.size();
+                    let new_size = current_size + size;
+                    if count >= MIN_KEYS_PER_NODE && new_size > threshold {
+                        split_indexes.push(i);
+                        current_size = HEADER_SIZE + size;
+                        count = 0;
+                    } else {
+                        current_size = new_size;
+                    }
+                }
+            }
+        };
+        // for some reason we didn't find a place to split
+        if split_indexes.is_empty() {
+            self.allocate();
+            return None;
+        }
 
-		let new_data: Vec<NodeData> = split_indexes
-			.iter()
-			// split from the end so we only break off small chunks at a time
-			.rev()
-			// split the data
-			.map(|i| self.data.split_at(*i))
-			.collect();
-		self.allocate();
+        let new_data: Vec<NodeData> = split_indexes
+            .iter()
+            // split from the end so we only break off small chunks at a time
+            .rev()
+            // split the data
+            .map(|i| self.data.split_at(*i))
+            .collect();
+        self.allocate();
 
-		Some(
-			new_data
-				.into_iter()
-				.rev()
-				.map(|data| {
-					let n = self.bucket.new_node(data);
-					n.allocate();
-					Branch::from_node(n)
-				})
-				.collect(),
-		)
-	}
+        Some(
+            new_data
+                .into_iter()
+                .rev()
+                .map(|data| {
+                    let n = self.bucket.new_node(data);
+                    n.allocate();
+                    Branch::from_node(n)
+                })
+                .collect(),
+        )
+    }
 }

--- a/src/page.rs
+++ b/src/page.rs
@@ -15,280 +15,280 @@ pub(crate) type PageType = u8;
 #[repr(C)]
 #[derive(Debug)]
 pub(crate) struct Page {
-	pub(crate) id: PageID,
-	pub(crate) page_type: PageType,
-	pub(crate) count: u64,
-	pub(crate) overflow: u64,
-	pub(crate) ptr: u64,
+    pub(crate) id: PageID,
+    pub(crate) page_type: PageType,
+    pub(crate) count: u64,
+    pub(crate) overflow: u64,
+    pub(crate) ptr: u64,
 }
 
 impl Page {
-	pub(crate) const TYPE_BRANCH: PageType = 0x01;
-	pub(crate) const TYPE_LEAF: PageType = 0x02;
-	pub(crate) const TYPE_META: PageType = 0x03;
-	pub(crate) const TYPE_FREELIST: PageType = 0x04;
+    pub(crate) const TYPE_BRANCH: PageType = 0x01;
+    pub(crate) const TYPE_LEAF: PageType = 0x02;
+    pub(crate) const TYPE_META: PageType = 0x03;
+    pub(crate) const TYPE_FREELIST: PageType = 0x04;
 
-	#[inline]
-	pub(crate) fn from_buf(buf: &[u8], id: PageID, pagesize: u64) -> &Page {
-		#[allow(clippy::cast_ptr_alignment)]
-		unsafe {
-			&*(&buf[(id * pagesize) as usize] as *const u8 as *const Page)
-		}
-	}
+    #[inline]
+    pub(crate) fn from_buf(buf: &[u8], id: PageID, pagesize: u64) -> &Page {
+        #[allow(clippy::cast_ptr_alignment)]
+        unsafe {
+            &*(&buf[(id * pagesize) as usize] as *const u8 as *const Page)
+        }
+    }
 
-	pub(crate) fn meta(&self) -> &Meta {
-		assert_eq!(self.page_type, Page::TYPE_META);
-		unsafe { &*(&self.ptr as *const u64 as *const Meta) }
-	}
+    pub(crate) fn meta(&self) -> &Meta {
+        assert_eq!(self.page_type, Page::TYPE_META);
+        unsafe { &*(&self.ptr as *const u64 as *const Meta) }
+    }
 
-	pub(crate) fn meta_mut(&mut self) -> &mut Meta {
-		assert_eq!(self.page_type, Page::TYPE_META);
-		unsafe { &mut *(&mut self.ptr as *mut u64 as *mut Meta) }
-	}
+    pub(crate) fn meta_mut(&mut self) -> &mut Meta {
+        assert_eq!(self.page_type, Page::TYPE_META);
+        unsafe { &mut *(&mut self.ptr as *mut u64 as *mut Meta) }
+    }
 
-	pub(crate) fn freelist(&self) -> &[PageID] {
-		assert_eq!(self.page_type, Page::TYPE_FREELIST);
-		unsafe {
-			let start = &self.ptr as *const u64 as *const PageID;
-			from_raw_parts(start, self.count as usize)
-		}
-	}
+    pub(crate) fn freelist(&self) -> &[PageID] {
+        assert_eq!(self.page_type, Page::TYPE_FREELIST);
+        unsafe {
+            let start = &self.ptr as *const u64 as *const PageID;
+            from_raw_parts(start, self.count as usize)
+        }
+    }
 
-	pub(crate) fn freelist_mut(&mut self) -> &mut [PageID] {
-		assert_eq!(self.page_type, Page::TYPE_FREELIST);
-		unsafe {
-			let start = &self.ptr as *const u64 as *mut PageID;
-			from_raw_parts_mut(start, self.count as usize)
-		}
-	}
+    pub(crate) fn freelist_mut(&mut self) -> &mut [PageID] {
+        assert_eq!(self.page_type, Page::TYPE_FREELIST);
+        unsafe {
+            let start = &self.ptr as *const u64 as *mut PageID;
+            from_raw_parts_mut(start, self.count as usize)
+        }
+    }
 
-	pub(crate) fn leaf_elements(&self) -> &[LeafElement] {
-		assert_eq!(self.page_type, Page::TYPE_LEAF);
-		unsafe {
-			let start = &self.ptr as *const u64 as *const LeafElement;
-			from_raw_parts(start, self.count as usize)
-		}
-	}
+    pub(crate) fn leaf_elements(&self) -> &[LeafElement] {
+        assert_eq!(self.page_type, Page::TYPE_LEAF);
+        unsafe {
+            let start = &self.ptr as *const u64 as *const LeafElement;
+            from_raw_parts(start, self.count as usize)
+        }
+    }
 
-	pub(crate) fn branch_elements(&self) -> &[BranchElement] {
-		assert_eq!(self.page_type, Page::TYPE_BRANCH);
-		unsafe {
-			let start = &self.ptr as *const u64 as *const BranchElement;
-			from_raw_parts(start, self.count as usize)
-		}
-	}
+    pub(crate) fn branch_elements(&self) -> &[BranchElement] {
+        assert_eq!(self.page_type, Page::TYPE_BRANCH);
+        unsafe {
+            let start = &self.ptr as *const u64 as *const BranchElement;
+            from_raw_parts(start, self.count as usize)
+        }
+    }
 
-	pub(crate) fn leaf_elements_mut(&mut self) -> &mut [LeafElement] {
-		assert_eq!(self.page_type, Page::TYPE_LEAF);
-		unsafe {
-			let start = &self.ptr as *const u64 as *const LeafElement as *mut LeafElement;
-			from_raw_parts_mut(start, self.count as usize)
-		}
-	}
+    pub(crate) fn leaf_elements_mut(&mut self) -> &mut [LeafElement] {
+        assert_eq!(self.page_type, Page::TYPE_LEAF);
+        unsafe {
+            let start = &self.ptr as *const u64 as *const LeafElement as *mut LeafElement;
+            from_raw_parts_mut(start, self.count as usize)
+        }
+    }
 
-	pub(crate) fn branch_elements_mut(&mut self) -> &mut [BranchElement] {
-		assert_eq!(self.page_type, Page::TYPE_BRANCH);
-		unsafe {
-			let start = &self.ptr as *const u64 as *const BranchElement as *mut BranchElement;
-			from_raw_parts_mut(start, self.count as usize)
-		}
-	}
+    pub(crate) fn branch_elements_mut(&mut self) -> &mut [BranchElement] {
+        assert_eq!(self.page_type, Page::TYPE_BRANCH);
+        unsafe {
+            let start = &self.ptr as *const u64 as *const BranchElement as *mut BranchElement;
+            from_raw_parts_mut(start, self.count as usize)
+        }
+    }
 
-	fn slice(&mut self, size: u64) -> &mut [u8] {
-		unsafe {
-			let start = &self.ptr as *const u64 as *const u8 as *mut u8;
-			from_raw_parts_mut(start, size as usize)
-		}
-	}
+    fn slice(&mut self, size: u64) -> &mut [u8] {
+        unsafe {
+            let start = &self.ptr as *const u64 as *const u8 as *mut u8;
+            from_raw_parts_mut(start, size as usize)
+        }
+    }
 
-	pub(crate) fn write_node(&mut self, n: &Node, num_pages: u64) -> Result<()> {
-		self.id = n.page_id;
-		self.count = n.data.len() as u64;
-		self.overflow = num_pages - 1;
-		let header_size;
-		let mut data_size: u64 = 0;
-		let mut data: Vec<&[u8]>;
-		match &n.data {
-			NodeData::Branches(branches) => {
-				self.page_type = Page::TYPE_BRANCH;
-				header_size = size_of::<BranchElement>() as u64;
-				let mut header_offsets = header_size * (branches.len() as u64);
-				data = Vec::with_capacity(self.count as usize);
-				let elems = self.branch_elements_mut();
-				for (b, elem) in branches.iter().zip(elems.iter_mut()) {
-					debug_assert!(b.page != 0, "PAGE SHOULD NOT BE ZERO!");
-					elem.page = b.page;
-					elem.key_size = b.key_size();
-					elem.pos = header_offsets + data_size;
-					data_size += elem.key_size;
-					header_offsets -= header_size;
-					data.push(b.key());
-				}
-			}
-			NodeData::Leaves(leaves) => {
-				self.page_type = Page::TYPE_LEAF;
-				header_size = size_of::<LeafElement>() as u64;
-				let mut header_offsets = header_size * (leaves.len() as u64);
-				data = Vec::with_capacity(self.count as usize * 2);
-				let elems = self.leaf_elements_mut();
-				for (l, elem) in leaves.iter().zip(elems.iter_mut()) {
-					elem.node_type = l.node_type();
+    pub(crate) fn write_node(&mut self, n: &Node, num_pages: u64) -> Result<()> {
+        self.id = n.page_id;
+        self.count = n.data.len() as u64;
+        self.overflow = num_pages - 1;
+        let header_size;
+        let mut data_size: u64 = 0;
+        let mut data: Vec<&[u8]>;
+        match &n.data {
+            NodeData::Branches(branches) => {
+                self.page_type = Page::TYPE_BRANCH;
+                header_size = size_of::<BranchElement>() as u64;
+                let mut header_offsets = header_size * (branches.len() as u64);
+                data = Vec::with_capacity(self.count as usize);
+                let elems = self.branch_elements_mut();
+                for (b, elem) in branches.iter().zip(elems.iter_mut()) {
+                    debug_assert!(b.page != 0, "PAGE SHOULD NOT BE ZERO!");
+                    elem.page = b.page;
+                    elem.key_size = b.key_size();
+                    elem.pos = header_offsets + data_size;
+                    data_size += elem.key_size;
+                    header_offsets -= header_size;
+                    data.push(b.key());
+                }
+            }
+            NodeData::Leaves(leaves) => {
+                self.page_type = Page::TYPE_LEAF;
+                header_size = size_of::<LeafElement>() as u64;
+                let mut header_offsets = header_size * (leaves.len() as u64);
+                data = Vec::with_capacity(self.count as usize * 2);
+                let elems = self.leaf_elements_mut();
+                for (l, elem) in leaves.iter().zip(elems.iter_mut()) {
+                    elem.node_type = l.node_type();
 
-					let key = l.key();
-					let value = l.value();
-					elem.key_size = key.len() as u64;
-					elem.value_size = value.len() as u64;
-					elem.pos = header_offsets + data_size;
+                    let key = l.key();
+                    let value = l.value();
+                    elem.key_size = key.len() as u64;
+                    elem.value_size = value.len() as u64;
+                    elem.pos = header_offsets + data_size;
 
-					data_size += elem.key_size + elem.value_size;
-					header_offsets -= header_size;
+                    data_size += elem.key_size + elem.value_size;
+                    header_offsets -= header_size;
 
-					data.push(key);
-					data.push(value);
-				}
-			}
-		};
-		let total_header = header_size * self.count;
-		let buf = self.slice(total_header + data_size);
-		let mut buf = &mut buf[(total_header as usize)..];
-		for b in data.iter() {
-			buf.write_all(b)?;
-		}
-		Ok(())
-	}
+                    data.push(key);
+                    data.push(value);
+                }
+            }
+        };
+        let total_header = header_size * self.count;
+        let buf = self.slice(total_header + data_size);
+        let mut buf = &mut buf[(total_header as usize)..];
+        for b in data.iter() {
+            buf.write_all(b)?;
+        }
+        Ok(())
+    }
 
-	#[cfg_attr(tarpaulin, skip)]
-	pub fn print(&self, tx: &TransactionInner) {
-		let name = self.name();
-		println!("{} [style=\"filled\", fillcolor=\"darkorchid1\"];", name);
-		match self.page_type {
-			Page::TYPE_BRANCH => {
-				for (i, elem) in self.branch_elements().iter().enumerate() {
-					let key = elem.key();
-					let elem_name =
-						format!("\"Index: {}\\nPage: {}\\nKey: {:?}\"", i, self.id, key);
-					let page = tx.page(elem.page);
-					println!("{} [style=\"filled\", fillcolor=\"burlywood\"];", elem_name);
-					println!("{} -> {}", name, elem_name);
-					println!("{} -> {}", elem_name, page.name());
-					page.print(tx);
-				}
-			}
-			Page::TYPE_LEAF => {
-				for (i, elem) in self.leaf_elements().iter().enumerate() {
-					match elem.node_type {
-						Node::TYPE_BUCKET => {
-							// let parts = SliceParts::from_slice(elem.value());
-							let bd = BucketData::from_slice_parts(
-								SliceParts::from_slice(elem.key()),
-								SliceParts::from_slice(elem.value()),
-							);
-							let meta = bd.meta();
-							let elem_name = format!(
-								"\"Index: {}\\nPage: {}\\nKey {:?}\\n {:?}\"",
-								i,
-								self.id,
-								elem.key(),
-								meta
-							);
-							println!("{} [style=\"filled\", fillcolor=\"gray91\"];", elem_name);
-							println!("{} -> {}", name, elem_name);
-							let page = tx.page(meta.root_page);
-							println!("{} -> {}", elem_name, page.name());
-							page.print(tx);
-						}
-						Node::TYPE_DATA => {
-							// return;
-							let elem_name = format!(
-								"\"Index: {}\\nPage: {}\\nKey: {:?}\\nValue '{}'\"",
-								i,
-								self.id,
-								elem.key(),
-								std::str::from_utf8(elem.value()).unwrap()
-							);
-							// let elem_name = format!("\"Index: {}\\nPage: {}\\nKey: '{}'\\nValue '{}'\"", i, self.id, std::str::from_utf8(elem.key()).unwrap(), std::str::from_utf8(elem.value()).unwrap());
-							println!(
-								"{} [style=\"filled\", fillcolor=\"chartreuse\"];",
-								elem_name
-							);
-							println!("{} -> {}", name, elem_name);
-						}
-						_ => panic!("LOL NOPE"),
-					}
-				}
-			}
-			_ => panic!(
-				"CANNOT WRITE NODE OF TYPE {} from page {}",
-				type_str(self.page_type),
-				self.id
-			),
-		}
-	}
+    #[cfg_attr(tarpaulin, skip)]
+    pub fn print(&self, tx: &TransactionInner) {
+        let name = self.name();
+        println!("{} [style=\"filled\", fillcolor=\"darkorchid1\"];", name);
+        match self.page_type {
+            Page::TYPE_BRANCH => {
+                for (i, elem) in self.branch_elements().iter().enumerate() {
+                    let key = elem.key();
+                    let elem_name =
+                        format!("\"Index: {}\\nPage: {}\\nKey: {:?}\"", i, self.id, key);
+                    let page = tx.page(elem.page);
+                    println!("{} [style=\"filled\", fillcolor=\"burlywood\"];", elem_name);
+                    println!("{} -> {}", name, elem_name);
+                    println!("{} -> {}", elem_name, page.name());
+                    page.print(tx);
+                }
+            }
+            Page::TYPE_LEAF => {
+                for (i, elem) in self.leaf_elements().iter().enumerate() {
+                    match elem.node_type {
+                        Node::TYPE_BUCKET => {
+                            // let parts = SliceParts::from_slice(elem.value());
+                            let bd = BucketData::from_slice_parts(
+                                SliceParts::from_slice(elem.key()),
+                                SliceParts::from_slice(elem.value()),
+                            );
+                            let meta = bd.meta();
+                            let elem_name = format!(
+                                "\"Index: {}\\nPage: {}\\nKey {:?}\\n {:?}\"",
+                                i,
+                                self.id,
+                                elem.key(),
+                                meta
+                            );
+                            println!("{} [style=\"filled\", fillcolor=\"gray91\"];", elem_name);
+                            println!("{} -> {}", name, elem_name);
+                            let page = tx.page(meta.root_page);
+                            println!("{} -> {}", elem_name, page.name());
+                            page.print(tx);
+                        }
+                        Node::TYPE_DATA => {
+                            // return;
+                            let elem_name = format!(
+                                "\"Index: {}\\nPage: {}\\nKey: {:?}\\nValue '{}'\"",
+                                i,
+                                self.id,
+                                elem.key(),
+                                std::str::from_utf8(elem.value()).unwrap()
+                            );
+                            // let elem_name = format!("\"Index: {}\\nPage: {}\\nKey: '{}'\\nValue '{}'\"", i, self.id, std::str::from_utf8(elem.key()).unwrap(), std::str::from_utf8(elem.value()).unwrap());
+                            println!(
+                                "{} [style=\"filled\", fillcolor=\"chartreuse\"];",
+                                elem_name
+                            );
+                            println!("{} -> {}", name, elem_name);
+                        }
+                        _ => panic!("LOL NOPE"),
+                    }
+                }
+            }
+            _ => panic!(
+                "CANNOT WRITE NODE OF TYPE {} from page {}",
+                type_str(self.page_type),
+                self.id
+            ),
+        }
+    }
 
-	#[cfg_attr(tarpaulin, skip)]
-	pub fn name(&self) -> String {
-		let size = 4096 + (self.overflow * 4096);
-		format!(
-			"\"Page #{} ({}) ({} bytes)\"",
-			self.id,
-			type_str(self.page_type),
-			size
-		)
-	}
+    #[cfg_attr(tarpaulin, skip)]
+    pub fn name(&self) -> String {
+        let size = 4096 + (self.overflow * 4096);
+        format!(
+            "\"Page #{} ({}) ({} bytes)\"",
+            self.id,
+            type_str(self.page_type),
+            size
+        )
+    }
 }
 
 #[cfg_attr(tarpaulin, skip)]
 fn type_str(pt: PageType) -> String {
-	match pt {
-		Page::TYPE_BRANCH => String::from("Branch"),
-		Page::TYPE_FREELIST => String::from("FreeList"),
-		Page::TYPE_LEAF => String::from("Leaf"),
-		Page::TYPE_META => String::from("Meta"),
-		_ => format!("Invalid ({:#X})", pt),
-	}
+    match pt {
+        Page::TYPE_BRANCH => String::from("Branch"),
+        Page::TYPE_FREELIST => String::from("FreeList"),
+        Page::TYPE_LEAF => String::from("Leaf"),
+        Page::TYPE_META => String::from("Meta"),
+        _ => format!("Invalid ({:#X})", pt),
+    }
 }
 
 #[repr(C)]
 pub(crate) struct BranchElement {
-	pub(crate) page: PageID,
-	key_size: u64,
-	pos: u64,
+    pub(crate) page: PageID,
+    key_size: u64,
+    pos: u64,
 }
 
 impl BranchElement {
-	pub(crate) fn key(&self) -> &[u8] {
-		let pos = self.pos as usize;
-		unsafe {
-			let start = self as *const BranchElement as *const u8;
-			let buf = std::slice::from_raw_parts(start, pos + (self.key_size as usize));
-			&buf[pos..]
-		}
-	}
+    pub(crate) fn key(&self) -> &[u8] {
+        let pos = self.pos as usize;
+        unsafe {
+            let start = self as *const BranchElement as *const u8;
+            let buf = std::slice::from_raw_parts(start, pos + (self.key_size as usize));
+            &buf[pos..]
+        }
+    }
 }
 
 #[repr(C)]
 pub(crate) struct LeafElement {
-	pub(crate) node_type: NodeType,
-	pos: u64,
-	key_size: u64,
-	value_size: u64,
+    pub(crate) node_type: NodeType,
+    pos: u64,
+    key_size: u64,
+    value_size: u64,
 }
 
 impl LeafElement {
-	pub(crate) fn key(&self) -> &[u8] {
-		let pos = self.pos as usize;
-		unsafe {
-			let start = self as *const LeafElement as *const u8;
-			let buf = std::slice::from_raw_parts(start, pos + self.key_size as usize);
-			&buf[pos..]
-		}
-	}
-	pub(crate) fn value(&self) -> &[u8] {
-		let pos = (self.pos + self.key_size) as usize;
-		unsafe {
-			let start = self as *const LeafElement as *const u8;
-			let buf = std::slice::from_raw_parts(start, pos + self.value_size as usize);
-			&buf[pos..]
-		}
-	}
+    pub(crate) fn key(&self) -> &[u8] {
+        let pos = self.pos as usize;
+        unsafe {
+            let start = self as *const LeafElement as *const u8;
+            let buf = std::slice::from_raw_parts(start, pos + self.key_size as usize);
+            &buf[pos..]
+        }
+    }
+    pub(crate) fn value(&self) -> &[u8] {
+        let pos = (self.pos + self.key_size) as usize;
+        unsafe {
+            let start = self as *const LeafElement as *const u8;
+            let buf = std::slice::from_raw_parts(start, pos + self.value_size as usize);
+            &buf[pos..]
+        }
+    }
 }

--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -4,36 +4,36 @@ use std::ops::{Deref, DerefMut};
 pub struct Ptr<T>(pub(crate) *const T);
 
 impl<T> Deref for Ptr<T> {
-	type Target = T;
+    type Target = T;
 
-	fn deref(&self) -> &Self::Target {
-		unsafe { &*self.0 }
-	}
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
 }
 
 impl<T> DerefMut for Ptr<T> {
-	fn deref_mut(&mut self) -> &mut Self::Target {
-		unsafe { &mut *(self.0 as *mut T) }
-	}
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *(self.0 as *mut T) }
+    }
 }
 
 impl<T> Ptr<T> {
-	pub(crate) fn new(a: &T) -> Ptr<T> {
-		Ptr(a as *const T)
-	}
+    pub(crate) fn new(a: &T) -> Ptr<T> {
+        Ptr(a as *const T)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn test_ptr() {
-		let val = 0_u8;
-		let mut ptr = Ptr::new(&val);
+    #[test]
+    fn test_ptr() {
+        let val = 0_u8;
+        let mut ptr = Ptr::new(&val);
 
-		assert_eq!(*(ptr.deref()), 0);
-		*ptr.deref_mut() = 8;
-		assert_eq!(*(ptr.deref()), 8);
-	}
+        assert_eq!(*(ptr.deref()), 0);
+        *ptr.deref_mut() = 8;
+        assert_eq!(*(ptr.deref()), 8);
+    }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -6,7 +6,6 @@ use std::sync::{Arc, MutexGuard};
 
 use memmap::Mmap;
 
-use crate::bucket::{Bucket, BucketRef};
 use crate::data::{BucketData, SliceParts};
 use crate::db::{DBInner, MIN_ALLOC_SIZE};
 use crate::errors::Error;
@@ -16,6 +15,10 @@ use crate::meta::Meta;
 use crate::node::Node;
 use crate::page::{Page, PageID};
 use crate::ptr::Ptr;
+use crate::{
+    bucket::{Bucket, BucketRef},
+    Ref,
+};
 
 /// An isolated view of the database
 ///
@@ -77,596 +80,605 @@ use crate::ptr::Ptr;
 /// reclaiming old pages and your database may increase in disk size quickly if you're writing lots of data,
 /// so it's a good idea to keep transactions short.
 pub struct Transaction<'a> {
-	inner: RefCell<Pin<Box<TransactionInner>>>,
-	file: Option<MutexGuard<'a, File>>,
+    inner: RefCell<Pin<Box<TransactionInner>>>,
+    file: Option<MutexGuard<'a, File>>,
 }
 
 impl<'a> Transaction<'a> {
-	pub(crate) fn new(db: &'a DBInner, writable: bool) -> Result<Transaction<'a>> {
-		let file = if writable {
-			Some(db.file.lock()?)
-		} else {
-			None
-		};
-		let tx = TransactionInner::new(db, writable)?;
-		let mut inner = Pin::new(Box::new(tx));
-		inner.init();
-		let inner = RefCell::new(inner);
-		Ok(Transaction { inner, file })
-	}
+    pub(crate) fn new(db: &'a DBInner, writable: bool) -> Result<Transaction<'a>> {
+        let file = if writable {
+            Some(db.file.lock()?)
+        } else {
+            None
+        };
+        let tx = TransactionInner::new(db, writable)?;
+        let mut inner = Pin::new(Box::new(tx));
+        inner.init();
+        let inner = RefCell::new(inner);
+        Ok(Transaction { inner, file })
+    }
 
-	/// Returns a reference to the root level bucket with the given name.
-	///
-	/// # Errors
-	///
-	/// Will return a [`BucketMissing`](enum.Error.html#variant.BucketMissing) error if the bucket does not exist,
-	/// or an [`IncompatibleValue`](enum.Error.html#variant.IncompatibleValue) error if the key exists but is not a bucket.
-	///
-	/// In a read-only transaction, you will get an error when trying to use any of the bucket's methods that modify data.
-	pub fn get_bucket<T: AsRef<[u8]>>(&'a self, name: T) -> Result<BucketRef> {
-		let mut inner = self.inner.borrow_mut();
-		Ok(BucketRef::new(unsafe {
-			&*inner.get_bucket(name.as_ref())?
-		}))
-	}
+    /// Returns a reference to the root level bucket with the given name.
+    ///
+    /// # Errors
+    ///
+    /// Will return a [`BucketMissing`](enum.Error.html#variant.BucketMissing) error if the bucket does not exist,
+    /// or an [`IncompatibleValue`](enum.Error.html#variant.IncompatibleValue) error if the key exists but is not a bucket.
+    ///
+    /// In a read-only transaction, you will get an error when trying to use any of the bucket's methods that modify data.
+    pub fn get_bucket<T: AsRef<[u8]>>(&'a self, name: T) -> Result<BucketRef> {
+        let mut inner = self.inner.borrow_mut();
+        Ok(BucketRef::new(unsafe {
+            &*inner.get_bucket(name.as_ref())?
+        }))
+    }
 
-	/// Creates a new bucket with the given name and returns a reference it.
-	///
-	/// # Errors
-	///
-	/// Will return a [`BucketExists`](enum.Error.html#variant.BucketExists) error if the bucket already exists,
-	/// an [`IncompatibleValue`](enum.Error.html#variant.IncompatibleValue) error if the key exists but is not a bucket,
-	/// or a [`ReadOnlyTx`](enum.Error.html#variant.ReadOnlyTx) error if this is called on a read-only transaction.
-	pub fn create_bucket<T: AsRef<[u8]>>(&'a self, name: T) -> Result<BucketRef> {
-		let mut inner = self.inner.borrow_mut();
-		Ok(BucketRef::new(unsafe {
-			&*inner.create_bucket(name.as_ref())?
-		}))
-	}
+    /// Creates a new bucket with the given name and returns a reference it.
+    ///
+    /// # Errors
+    ///
+    /// Will return a [`BucketExists`](enum.Error.html#variant.BucketExists) error if the bucket already exists,
+    /// an [`IncompatibleValue`](enum.Error.html#variant.IncompatibleValue) error if the key exists but is not a bucket,
+    /// or a [`ReadOnlyTx`](enum.Error.html#variant.ReadOnlyTx) error if this is called on a read-only transaction.
+    pub fn create_bucket<T: AsRef<[u8]>>(&'a self, name: T) -> Result<BucketRef> {
+        let mut inner = self.inner.borrow_mut();
+        Ok(BucketRef::new(unsafe {
+            &*inner.create_bucket(name.as_ref())?
+        }))
+    }
 
-	/// Creates an existing root-level bucket with the given name if it does not already exist.
-	/// Gets the existing bucket if it does exist.
-	///
-	/// # Errors
-	///
-	/// Will return an [`IncompatibleValue`](enum.Error.html#variant.IncompatibleValue) error if the key exists but is not a bucket,
-	/// or a [`ReadOnlyTx`](enum.Error.html#variant.ReadOnlyTx) error if this is called on a read-only transaction.
-	pub fn get_or_create_bucket<T: AsRef<[u8]>>(&self, name: T) -> Result<BucketRef> {
-		let mut inner = self.inner.borrow_mut();
-		Ok(BucketRef::new(unsafe {
-			&*inner.get_or_create_bucket(name.as_ref())?
-		}))
-	}
+    /// Creates an existing root-level bucket with the given name if it does not already exist.
+    /// Gets the existing bucket if it does exist.
+    ///
+    /// # Errors
+    ///
+    /// Will return an [`IncompatibleValue`](enum.Error.html#variant.IncompatibleValue) error if the key exists but is not a bucket,
+    /// or a [`ReadOnlyTx`](enum.Error.html#variant.ReadOnlyTx) error if this is called on a read-only transaction.
+    pub fn get_or_create_bucket<T: AsRef<[u8]>>(&self, name: T) -> Result<BucketRef> {
+        let mut inner = self.inner.borrow_mut();
+        Ok(BucketRef::new(unsafe {
+            &*inner.get_or_create_bucket(name.as_ref())?
+        }))
+    }
 
-	/// Deletes an existing root-level bucket with the given name
-	///
-	/// # Errors
-	///
-	/// Will return a [`BucketMissing`](enum.Error.html#variant.BucketMissing) error if the bucket does not exist,
-	/// an [`IncompatibleValue`](enum.Error.html#variant.IncompatibleValue) error if the key exists but is not a bucket,
-	/// or a [`ReadOnlyTx`](enum.Error.html#variant.ReadOnlyTx) error if this is called on a read-only transaction.
-	pub fn delete_bucket<T: AsRef<[u8]>>(&self, name: T) -> Result<()> {
-		self.inner.borrow_mut().delete_bucket(name.as_ref())
-	}
+    /// Deletes an existing root-level bucket with the given name
+    ///
+    /// # Errors
+    ///
+    /// Will return a [`BucketMissing`](enum.Error.html#variant.BucketMissing) error if the bucket does not exist,
+    /// an [`IncompatibleValue`](enum.Error.html#variant.IncompatibleValue) error if the key exists but is not a bucket,
+    /// or a [`ReadOnlyTx`](enum.Error.html#variant.ReadOnlyTx) error if this is called on a read-only transaction.
+    pub fn delete_bucket<T: AsRef<[u8]>>(&self, name: T) -> Result<()> {
+        self.inner.borrow_mut().delete_bucket(name.as_ref())
+    }
 
-	/// Writes the changes made in the writeable transaction to the underlying file.
-	///
-	/// # Errors
-	///
-	/// Will return an [`IOError`](enum.Error.html#variant.IOError) error if there are any io errors while writing to disk,
-	/// or a [`ReadOnlyTx`](enum.Error.html#variant.ReadOnlyTx) error if this is called on a read-only transaction.
-	pub fn commit(mut self) -> Result<()> {
-		let mut inner = self.inner.borrow_mut();
-		if !inner.writable {
-			return Err(Error::ReadOnlyTx);
-		}
-		inner.rebalance()?;
-		inner.write_data(&mut self.file.as_mut().unwrap())
-	}
+    /// Writes the changes made in the writeable transaction to the underlying file.
+    ///
+    /// # Errors
+    ///
+    /// Will return an [`IOError`](enum.Error.html#variant.IOError) error if there are any io errors while writing to disk,
+    /// or a [`ReadOnlyTx`](enum.Error.html#variant.ReadOnlyTx) error if this is called on a read-only transaction.
+    pub fn commit(mut self) -> Result<()> {
+        let mut inner = self.inner.borrow_mut();
+        if !inner.writable {
+            return Err(Error::ReadOnlyTx);
+        }
+        inner.rebalance()?;
+        inner.write_data(&mut self.file.as_mut().unwrap())
+    }
 
-	#[doc(hidden)]
-	#[cfg_attr(tarpaulin, skip)]
-	pub fn print_graph(&self) {
-		println!("digraph G {{");
-		self.inner.borrow_mut().root.as_ref().unwrap().print();
-		println!("}}");
-	}
+    /// Iterator over the root level buckets
+    pub fn buckets(&self) -> impl Iterator<Item = (Ref<BucketData>, BucketRef)> {
+        let inner = self.inner.borrow();
+        let root = inner.root.as_ref().unwrap();
+        let ptr = root as *const Bucket;
+        let b = unsafe { &*ptr };
+        b.sub_buckets()
+    }
 
-	pub(crate) fn check(&self) -> Result<()> {
-		self.inner.borrow_mut().check()
-	}
+    #[doc(hidden)]
+    #[cfg_attr(tarpaulin, skip)]
+    pub fn print_graph(&self) {
+        println!("digraph G {{");
+        self.inner.borrow_mut().root.as_ref().unwrap().print();
+        println!("}}");
+    }
+
+    pub(crate) fn check(&self) -> Result<()> {
+        self.inner.borrow_mut().check()
+    }
 }
 
 pub(crate) struct TransactionInner {
-	pub(crate) db: Ptr<DBInner>,
-	pub(crate) meta: Meta,
-	pub(crate) writable: bool,
-	pub(crate) freelist: Freelist,
-	data: Arc<Mmap>,
-	root: Option<Bucket>,
-	buffers: Vec<Vec<u8>>,
+    pub(crate) db: Ptr<DBInner>,
+    pub(crate) meta: Meta,
+    pub(crate) writable: bool,
+    pub(crate) freelist: Freelist,
+    data: Arc<Mmap>,
+    root: Option<Bucket>,
+    buffers: Vec<Vec<u8>>,
 }
 
 impl<'a> TransactionInner {
-	fn new(db: &DBInner, writable: bool) -> Result<TransactionInner> {
-		let mut meta: Meta = db.meta();
-		let mut freelist = db.freelist.clone();
-		{
-			let mut open_ro_txs = db.open_ro_txs.lock().unwrap();
-			if writable {
-				meta.tx_id += 1;
-				if open_ro_txs.len() > 0 {
-					freelist.release(open_ro_txs[0]);
-				} else {
-					freelist.release(meta.tx_id);
-				}
-			} else {
-				open_ro_txs.push(meta.tx_id);
-				open_ro_txs.sort_unstable();
-			}
-		}
-		let _lock = db.mmap_lock.lock()?;
-		let data = db.data.clone();
+    fn new(db: &DBInner, writable: bool) -> Result<TransactionInner> {
+        let mut meta: Meta = db.meta();
+        let mut freelist = db.freelist.clone();
+        {
+            let mut open_ro_txs = db.open_ro_txs.lock().unwrap();
+            if writable {
+                meta.tx_id += 1;
+                if open_ro_txs.len() > 0 {
+                    freelist.release(open_ro_txs[0]);
+                } else {
+                    freelist.release(meta.tx_id);
+                }
+            } else {
+                open_ro_txs.push(meta.tx_id);
+                open_ro_txs.sort_unstable();
+            }
+        }
+        let _lock = db.mmap_lock.lock()?;
+        let data = db.data.clone();
 
-		let tx = TransactionInner {
-			db: Ptr::new(db),
-			meta,
-			writable,
-			freelist,
-			data,
-			root: None,
-			buffers: Vec::new(),
-		};
-		Ok(tx)
-	}
+        let tx = TransactionInner {
+            db: Ptr::new(db),
+            meta,
+            writable,
+            freelist,
+            data,
+            root: None,
+            buffers: Vec::new(),
+        };
+        Ok(tx)
+    }
 
-	fn init(&mut self) {
-		let ptr = Ptr::new(self);
-		self.root = Some(Bucket::root(ptr));
-	}
+    fn init(&mut self) {
+        let ptr = Ptr::new(self);
+        self.root = Some(Bucket::root(ptr));
+    }
 
-	#[inline]
-	pub(crate) fn page(&self, id: u64) -> &Page {
-		Page::from_buf(&self.data, id, self.db.pagesize)
-	}
+    #[inline]
+    pub(crate) fn page(&self, id: u64) -> &Page {
+        Page::from_buf(&self.data, id, self.db.pagesize)
+    }
 
-	fn get_bucket(&mut self, name: &[u8]) -> Result<*const Bucket> {
-		let root = self.root.as_mut().unwrap();
-		Ok(&*root.get_bucket(name)?)
-	}
+    fn get_bucket(&mut self, name: &[u8]) -> Result<*const Bucket> {
+        let root = self.root.as_mut().unwrap();
+        Ok(&*root.get_bucket(name)?)
+    }
 
-	fn get_or_create_bucket(&mut self, name: &[u8]) -> Result<*const Bucket> {
-		let root = self.root.as_mut().unwrap();
-		Ok(&*root.get_or_create_bucket(name)?)
-	}
+    fn get_or_create_bucket(&mut self, name: &[u8]) -> Result<*const Bucket> {
+        let root = self.root.as_mut().unwrap();
+        Ok(&*root.get_or_create_bucket(name)?)
+    }
 
-	fn create_bucket(&mut self, name: &[u8]) -> Result<*const Bucket> {
-		let root = self.root.as_mut().unwrap();
-		Ok(&*root.create_bucket(name)?)
-	}
+    fn create_bucket(&mut self, name: &[u8]) -> Result<*const Bucket> {
+        let root = self.root.as_mut().unwrap();
+        Ok(&*root.create_bucket(name)?)
+    }
 
-	fn delete_bucket(&mut self, name: &[u8]) -> Result<()> {
-		let root = self.root.as_mut().unwrap();
-		root.delete_bucket(name)
-	}
+    fn delete_bucket(&mut self, name: &[u8]) -> Result<()> {
+        let root = self.root.as_mut().unwrap();
+        root.delete_bucket(name)
+    }
 
-	pub(crate) fn copy_data(&mut self, data: &[u8]) -> SliceParts {
-		let data = Vec::from(data);
-		self.buffers.push(data);
-		SliceParts::from_slice(&self.buffers.last().unwrap()[..])
-	}
+    pub(crate) fn copy_data(&mut self, data: &[u8]) -> SliceParts {
+        let data = Vec::from(data);
+        self.buffers.push(data);
+        SliceParts::from_slice(&self.buffers.last().unwrap()[..])
+    }
 
-	pub(crate) fn free(&mut self, page_id: PageID, num_pages: u64) {
-		for id in page_id..(page_id + num_pages) {
-			self.freelist.free(self.meta.tx_id, id);
-		}
-	}
+    pub(crate) fn free(&mut self, page_id: PageID, num_pages: u64) {
+        for id in page_id..(page_id + num_pages) {
+            self.freelist.free(self.meta.tx_id, id);
+        }
+    }
 
-	pub(crate) fn allocate(&mut self, bytes: u64) -> (PageID, u64) {
-		let num_pages = if (bytes % self.db.pagesize) == 0 {
-			bytes / self.db.pagesize
-		} else {
-			(bytes / self.db.pagesize) + 1
-		};
-		let page_id = match self.freelist.allocate(num_pages as usize) {
-			Some(page_id) => page_id,
-			None => {
-				let page_id = self.meta.num_pages;
-				self.meta.num_pages += num_pages;
-				page_id
-			}
-		};
-		(page_id, num_pages)
-	}
+    pub(crate) fn allocate(&mut self, bytes: u64) -> (PageID, u64) {
+        let num_pages = if (bytes % self.db.pagesize) == 0 {
+            bytes / self.db.pagesize
+        } else {
+            (bytes / self.db.pagesize) + 1
+        };
+        let page_id = match self.freelist.allocate(num_pages as usize) {
+            Some(page_id) => page_id,
+            None => {
+                let page_id = self.meta.num_pages;
+                self.meta.num_pages += num_pages;
+                page_id
+            }
+        };
+        (page_id, num_pages)
+    }
 
-	fn rebalance(&mut self) -> Result<()> {
-		let root = self.root.as_mut().unwrap();
-		root.rebalance()?;
-		Ok(())
-	}
+    fn rebalance(&mut self) -> Result<()> {
+        let root = self.root.as_mut().unwrap();
+        root.rebalance()?;
+        Ok(())
+    }
 
-	fn write_data(&mut self, file: &mut File) -> Result<()> {
-		let required_size = (self.meta.num_pages * self.db.pagesize) as u64;
-		let current_size = file.metadata()?.len();
-		if current_size < required_size {
-			let size_diff = required_size - current_size;
-			let alloc_size = ((size_diff / MIN_ALLOC_SIZE) + 1) * MIN_ALLOC_SIZE;
-			self.db.resize(file, current_size + alloc_size)?;
-		}
+    fn write_data(&mut self, file: &mut File) -> Result<()> {
+        let required_size = (self.meta.num_pages * self.db.pagesize) as u64;
+        let current_size = file.metadata()?.len();
+        if current_size < required_size {
+            let size_diff = required_size - current_size;
+            let alloc_size = ((size_diff / MIN_ALLOC_SIZE) + 1) * MIN_ALLOC_SIZE;
+            self.db.resize(file, current_size + alloc_size)?;
+        }
 
-		// write the data to the file
-		{
-			let root = self.root.as_mut().unwrap();
-			root.write(file)?;
-			self.meta.root = root.meta();
-		}
+        // write the data to the file
+        {
+            let root = self.root.as_mut().unwrap();
+            root.write(file)?;
+            self.meta.root = root.meta();
+        }
 
-		// write freelist to file
-		{
-			self.freelist.free(self.meta.tx_id, self.meta.freelist_page);
-			let (page_id, num_pages) = self.allocate(self.freelist.size());
-			let page_ids = self.freelist.pages();
-			let size = self.freelist.size();
+        // write freelist to file
+        {
+            self.freelist.free(self.meta.tx_id, self.meta.freelist_page);
+            let (page_id, num_pages) = self.allocate(self.freelist.size());
+            let page_ids = self.freelist.pages();
+            let size = self.freelist.size();
 
-			let mut buf = vec![0; size as usize];
+            let mut buf = vec![0; size as usize];
 
-			#[allow(clippy::cast_ptr_alignment)]
-			let mut page = unsafe { &mut *(&mut buf[0] as *mut u8 as *mut Page) };
-			page.id = page_id;
-			page.overflow = num_pages - 1;
-			page.page_type = Page::TYPE_FREELIST;
-			page.count = page_ids.len() as u64;
-			page.freelist_mut().copy_from_slice(page_ids.as_slice());
+            #[allow(clippy::cast_ptr_alignment)]
+            let mut page = unsafe { &mut *(&mut buf[0] as *mut u8 as *mut Page) };
+            page.id = page_id;
+            page.overflow = num_pages - 1;
+            page.page_type = Page::TYPE_FREELIST;
+            page.count = page_ids.len() as u64;
+            page.freelist_mut().copy_from_slice(page_ids.as_slice());
 
-			file.seek(SeekFrom::Start((self.db.pagesize * page_id) as u64))?;
-			file.write_all(buf.as_slice())?;
+            file.seek(SeekFrom::Start((self.db.pagesize * page_id) as u64))?;
+            file.write_all(buf.as_slice())?;
 
-			self.meta.freelist_page = page_id;
-		}
+            self.meta.freelist_page = page_id;
+        }
 
-		// write meta page to file
-		{
-			let mut buf = vec![0; self.db.pagesize as usize];
+        // write meta page to file
+        {
+            let mut buf = vec![0; self.db.pagesize as usize];
 
-			#[allow(clippy::cast_ptr_alignment)]
-			let mut page = unsafe { &mut *(&mut buf[0] as *mut u8 as *mut Page) };
-			let meta_page_id = if self.meta.meta_page == 0 { 1 } else { 0 };
-			page.id = meta_page_id;
-			page.page_type = Page::TYPE_META;
-			let m = page.meta_mut();
-			m.meta_page = meta_page_id as u8;
-			m.magic = self.meta.magic;
-			m.version = self.meta.version;
-			m.pagesize = self.meta.pagesize;
-			m.root = self.meta.root;
-			m.num_pages = self.meta.num_pages;
-			m.freelist_page = self.meta.freelist_page;
-			m.tx_id = self.meta.tx_id;
-			m.hash = m.hash_self();
+            #[allow(clippy::cast_ptr_alignment)]
+            let mut page = unsafe { &mut *(&mut buf[0] as *mut u8 as *mut Page) };
+            let meta_page_id = if self.meta.meta_page == 0 { 1 } else { 0 };
+            page.id = meta_page_id;
+            page.page_type = Page::TYPE_META;
+            let m = page.meta_mut();
+            m.meta_page = meta_page_id as u8;
+            m.magic = self.meta.magic;
+            m.version = self.meta.version;
+            m.pagesize = self.meta.pagesize;
+            m.root = self.meta.root;
+            m.num_pages = self.meta.num_pages;
+            m.freelist_page = self.meta.freelist_page;
+            m.tx_id = self.meta.tx_id;
+            m.hash = m.hash_self();
 
-			file.seek(SeekFrom::Start((self.db.pagesize * meta_page_id) as u64))?;
-			file.write_all(buf.as_slice())?;
-		}
+            file.seek(SeekFrom::Start((self.db.pagesize * meta_page_id) as u64))?;
+            file.write_all(buf.as_slice())?;
+        }
 
-		file.flush()?;
-		file.sync_all()?;
+        file.flush()?;
+        file.sync_all()?;
 
-		self.db.freelist = self.freelist.clone();
-		Ok(())
-	}
+        self.db.freelist = self.freelist.clone();
+        Ok(())
+    }
 
-	fn check(&self) -> Result<()> {
-		use std::collections::HashSet;
-		let mut unused_pages: HashSet<PageID> = (2..self.meta.num_pages).collect();
-		let mut page_stack = Vec::new();
-		page_stack.push(self.meta.root.root_page);
-		page_stack.push(self.meta.freelist_page);
-		while !page_stack.is_empty() {
-			let page_id = page_stack.pop().unwrap();
-			if !unused_pages.remove(&page_id) {
-				#[cfg_attr(tarpaulin, skip)]
-				return Err(Error::InvalidDB(format!(
-					"Page {} missing from unused_pages",
-					page_id,
-				)));
-			}
-			let page = self.page(page_id);
-			for i in 0..page.overflow {
-				let page_id = page_id + i + 1;
-				if !unused_pages.remove(&page_id) {
-					#[cfg_attr(tarpaulin, skip)]
-					return Err(Error::InvalidDB(format!(
-						"Overflow Page {} from missing from unused_pages",
-						page_id,
-					)));
-				}
-			}
-			match page.page_type {
-				Page::TYPE_BRANCH => {
-					let mut last: Option<&[u8]> = None;
-					for (i, b) in page.branch_elements().iter().enumerate() {
-						page_stack.push(b.page);
-						if i > 0 && last.unwrap() >= b.key() {
-							#[cfg_attr(tarpaulin, skip)]
-							return Err(Error::InvalidDB(format!(
-								"Page {} contains unsorted elements",
-								page_id
-							)));
-						}
-						last = Some(b.key());
-					}
-				}
-				Page::TYPE_LEAF => {
-					let mut last: Option<&[u8]> = None;
-					for (i, leaf) in page.leaf_elements().iter().enumerate() {
-						match leaf.node_type {
-							Node::TYPE_BUCKET => {
-								let bucket_data = BucketData::new(leaf.key(), leaf.value());
-								page_stack.push(bucket_data.meta().root_page);
-							}
-							Node::TYPE_DATA => (),
-							_ =>
-							{
-								#[cfg_attr(tarpaulin, skip)]
-								return Err(Error::InvalidDB(format!(
-									"Page {} index {} has an invalid node type {}",
-									page_id, i, leaf.node_type,
-								)))
-							}
-						}
-						if i > 0 && last.unwrap() >= leaf.key() {
-							#[cfg_attr(tarpaulin, skip)]
-							return Err(Error::InvalidDB(format!(
-								"Page {} contains unsorted elements",
-								page_id
-							)));
-						}
-						last = Some(leaf.key());
-					}
-				}
-				Page::TYPE_FREELIST => {
-					if page_id != self.meta.freelist_page {
-						return Err(Error::InvalidDB(format!(
-							"Found Invalid Freelist Page {}",
-							page_id
-						)));
-					}
-					for page_id in page.freelist() {
-						if !unused_pages.remove(&page_id) {
-							#[cfg_attr(tarpaulin, skip)]
-							return Err(Error::InvalidDB(format!(
-								"Page {} from freelist missing from unused_pages",
-								page_id,
-							)));
-						}
-					}
-				}
-				_ =>
-				{
-					#[cfg_attr(tarpaulin, skip)]
-					return Err(Error::InvalidDB(format!(
-						"Invalid page type {} for page {}",
-						page.page_type, page_id,
-					)))
-				}
-			}
-		}
-		if !unused_pages.is_empty() {
-			#[cfg_attr(tarpaulin, skip)]
-			return Err(Error::InvalidDB(format!(
-				"Unreachable pages {:?}",
-				unused_pages,
-			)));
-		}
-		Ok(())
-	}
+    fn check(&self) -> Result<()> {
+        use std::collections::HashSet;
+        let mut unused_pages: HashSet<PageID> = (2..self.meta.num_pages).collect();
+        let mut page_stack = Vec::new();
+        page_stack.push(self.meta.root.root_page);
+        page_stack.push(self.meta.freelist_page);
+        while !page_stack.is_empty() {
+            let page_id = page_stack.pop().unwrap();
+            if !unused_pages.remove(&page_id) {
+                #[cfg_attr(tarpaulin, skip)]
+                return Err(Error::InvalidDB(format!(
+                    "Page {} missing from unused_pages",
+                    page_id,
+                )));
+            }
+            let page = self.page(page_id);
+            for i in 0..page.overflow {
+                let page_id = page_id + i + 1;
+                if !unused_pages.remove(&page_id) {
+                    #[cfg_attr(tarpaulin, skip)]
+                    return Err(Error::InvalidDB(format!(
+                        "Overflow Page {} from missing from unused_pages",
+                        page_id,
+                    )));
+                }
+            }
+            match page.page_type {
+                Page::TYPE_BRANCH => {
+                    let mut last: Option<&[u8]> = None;
+                    for (i, b) in page.branch_elements().iter().enumerate() {
+                        page_stack.push(b.page);
+                        if i > 0 && last.unwrap() >= b.key() {
+                            #[cfg_attr(tarpaulin, skip)]
+                            return Err(Error::InvalidDB(format!(
+                                "Page {} contains unsorted elements",
+                                page_id
+                            )));
+                        }
+                        last = Some(b.key());
+                    }
+                }
+                Page::TYPE_LEAF => {
+                    let mut last: Option<&[u8]> = None;
+                    for (i, leaf) in page.leaf_elements().iter().enumerate() {
+                        match leaf.node_type {
+                            Node::TYPE_BUCKET => {
+                                let bucket_data = BucketData::new(leaf.key(), leaf.value());
+                                page_stack.push(bucket_data.meta().root_page);
+                            }
+                            Node::TYPE_DATA => (),
+                            _ =>
+                            {
+                                #[cfg_attr(tarpaulin, skip)]
+                                return Err(Error::InvalidDB(format!(
+                                    "Page {} index {} has an invalid node type {}",
+                                    page_id, i, leaf.node_type,
+                                )))
+                            }
+                        }
+                        if i > 0 && last.unwrap() >= leaf.key() {
+                            #[cfg_attr(tarpaulin, skip)]
+                            return Err(Error::InvalidDB(format!(
+                                "Page {} contains unsorted elements",
+                                page_id
+                            )));
+                        }
+                        last = Some(leaf.key());
+                    }
+                }
+                Page::TYPE_FREELIST => {
+                    if page_id != self.meta.freelist_page {
+                        return Err(Error::InvalidDB(format!(
+                            "Found Invalid Freelist Page {}",
+                            page_id
+                        )));
+                    }
+                    for page_id in page.freelist() {
+                        if !unused_pages.remove(&page_id) {
+                            #[cfg_attr(tarpaulin, skip)]
+                            return Err(Error::InvalidDB(format!(
+                                "Page {} from freelist missing from unused_pages",
+                                page_id,
+                            )));
+                        }
+                    }
+                }
+                _ =>
+                {
+                    #[cfg_attr(tarpaulin, skip)]
+                    return Err(Error::InvalidDB(format!(
+                        "Invalid page type {} for page {}",
+                        page.page_type, page_id,
+                    )))
+                }
+            }
+        }
+        if !unused_pages.is_empty() {
+            #[cfg_attr(tarpaulin, skip)]
+            return Err(Error::InvalidDB(format!(
+                "Unreachable pages {:?}",
+                unused_pages,
+            )));
+        }
+        Ok(())
+    }
 }
 
 impl Drop for TransactionInner {
-	fn drop(&mut self) {
-		if !self.writable {
-			let mut open_txs = self.db.open_ro_txs.lock().unwrap();
-			let index = match open_txs.binary_search(&self.meta.tx_id) {
-				Ok(i) => i,
-				_ => return, // this shouldn't happen, but isn't the end of the world if it does
-			};
-			open_txs.remove(index);
-		}
-	}
+    fn drop(&mut self) {
+        if !self.writable {
+            let mut open_txs = self.db.open_ro_txs.lock().unwrap();
+            let index = match open_txs.binary_search(&self.meta.tx_id) {
+                Ok(i) => i,
+                _ => return, // this shouldn't happen, but isn't the end of the world if it does
+            };
+            open_txs.remove(index);
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use crate::db::{OpenOptions, DB};
-	use crate::testutil::RandomFile;
+    use super::*;
+    use crate::db::{OpenOptions, DB};
+    use crate::testutil::RandomFile;
 
-	#[test]
-	fn test_ro_txs() -> Result<()> {
-		let random_file = RandomFile::new();
-		let db = DB::open(&random_file)?;
+    #[test]
+    fn test_ro_txs() -> Result<()> {
+        let random_file = RandomFile::new();
+        let db = DB::open(&random_file)?;
 
-		{
-			let tx = db.tx(true)?;
-			assert!(tx.create_bucket("abc").is_ok());
-			tx.commit()?;
-		}
+        {
+            let tx = db.tx(true)?;
+            assert!(tx.create_bucket("abc").is_ok());
+            tx.commit()?;
+        }
 
-		let tx = db.tx(false)?;
-		assert!(tx.create_bucket("def").is_err());
-		let b = tx.get_bucket("abc")?;
-		assert_eq!(b.put("key", "value"), Err(Error::ReadOnlyTx));
-		assert_eq!(b.delete("key"), Err(Error::ReadOnlyTx));
-		assert_eq!(b.create_bucket("dev").err(), Some(Error::ReadOnlyTx));
-		assert_eq!(tx.commit(), Err(Error::ReadOnlyTx));
+        let tx = db.tx(false)?;
+        assert!(tx.create_bucket("def").is_err());
+        let b = tx.get_bucket("abc")?;
+        assert_eq!(b.put("key", "value"), Err(Error::ReadOnlyTx));
+        assert_eq!(b.delete("key"), Err(Error::ReadOnlyTx));
+        assert_eq!(b.create_bucket("dev").err(), Some(Error::ReadOnlyTx));
+        assert_eq!(tx.commit(), Err(Error::ReadOnlyTx));
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	#[test]
-	fn test_concurrent_txs() -> Result<()> {
-		let random_file = RandomFile::new();
-		let db = OpenOptions::new()
-			.pagesize(1024)
-			.num_pages(4)
-			.open(&random_file)?;
-		{
-			// create a read-only tx
-			let tx = db.tx(false)?;
-			assert!(tx.file.is_none());
-			let tx = tx.inner.borrow_mut();
-			assert_eq!(tx.data.len(), 1024 * 4);
-			assert!(tx.root.is_some());
-			{
-				let open_ro_txs = tx.db.open_ro_txs.lock().unwrap();
-				assert_eq!(open_ro_txs.len(), 1);
-				assert_eq!(open_ro_txs[0], tx.meta.tx_id);
-			}
-			{
-				// create a writable transaction while the read-only transaction is still open
-				let tx = db.tx(true)?;
-				assert!(tx.file.is_some());
-				{
-					{
-						let inner = tx.inner.borrow_mut();
-						assert_eq!(inner.meta.tx_id, 1);
-						assert_eq!(inner.freelist.pages(), vec![]);
-					}
-					let b = tx.create_bucket("abc")?;
-					b.put("123", "456")?;
-				}
-				tx.commit()?;
-			}
-			{
-				// create a second writable transaction while the read-only transaction is still open
-				let tx = db.tx(true)?;
-				assert!(tx.file.is_some());
-				{
-					{
-						let inner = tx.inner.borrow_mut();
-						assert_eq!(inner.meta.tx_id, 2);
-						assert_eq!(inner.freelist.pages(), vec![2, 3]);
-					}
-					let b = tx.get_bucket("abc")?;
-					b.put("123", "456")?;
-				}
-				tx.commit()?;
-			}
-			// let the read-only tx drop
-		}
-		{
-			// make sure we can reuse the freelist
-			let tx = db.tx(true)?;
-			assert!(tx.file.is_some());
-			let mut inner = tx.inner.borrow_mut();
-			assert_eq!(inner.freelist.pages(), vec![2, 3, 4, 5, 6]);
-			// allocate some pages from the freelist
-			assert_eq!(inner.meta.num_pages, 10);
-			assert_eq!(inner.allocate(1), (2, 1));
-			assert_eq!(inner.allocate(1), (3, 1));
-			assert_eq!(inner.allocate(1), (4, 1));
-			assert_eq!(inner.allocate(1), (5, 1));
-			assert_eq!(inner.allocate(1), (6, 1));
-			// freelist should be empty so make sure the page is new
-			assert_eq!(inner.meta.num_pages, 10);
-			assert_eq!(inner.allocate(1), (10, 1));
-			assert_eq!(inner.meta.num_pages, 11);
-			assert_eq!(inner.freelist.pages(), vec![]);
-		}
-		Ok(())
-	}
+    #[test]
+    fn test_concurrent_txs() -> Result<()> {
+        let random_file = RandomFile::new();
+        let db = OpenOptions::new()
+            .pagesize(1024)
+            .num_pages(4)
+            .open(&random_file)?;
+        {
+            // create a read-only tx
+            let tx = db.tx(false)?;
+            assert!(tx.file.is_none());
+            let tx = tx.inner.borrow_mut();
+            assert_eq!(tx.data.len(), 1024 * 4);
+            assert!(tx.root.is_some());
+            {
+                let open_ro_txs = tx.db.open_ro_txs.lock().unwrap();
+                assert_eq!(open_ro_txs.len(), 1);
+                assert_eq!(open_ro_txs[0], tx.meta.tx_id);
+            }
+            {
+                // create a writable transaction while the read-only transaction is still open
+                let tx = db.tx(true)?;
+                assert!(tx.file.is_some());
+                {
+                    {
+                        let inner = tx.inner.borrow_mut();
+                        assert_eq!(inner.meta.tx_id, 1);
+                        assert_eq!(inner.freelist.pages(), vec![]);
+                    }
+                    let b = tx.create_bucket("abc")?;
+                    b.put("123", "456")?;
+                }
+                tx.commit()?;
+            }
+            {
+                // create a second writable transaction while the read-only transaction is still open
+                let tx = db.tx(true)?;
+                assert!(tx.file.is_some());
+                {
+                    {
+                        let inner = tx.inner.borrow_mut();
+                        assert_eq!(inner.meta.tx_id, 2);
+                        assert_eq!(inner.freelist.pages(), vec![2, 3]);
+                    }
+                    let b = tx.get_bucket("abc")?;
+                    b.put("123", "456")?;
+                }
+                tx.commit()?;
+            }
+            // let the read-only tx drop
+        }
+        {
+            // make sure we can reuse the freelist
+            let tx = db.tx(true)?;
+            assert!(tx.file.is_some());
+            let mut inner = tx.inner.borrow_mut();
+            assert_eq!(inner.freelist.pages(), vec![2, 3, 4, 5, 6]);
+            // allocate some pages from the freelist
+            assert_eq!(inner.meta.num_pages, 10);
+            assert_eq!(inner.allocate(1), (2, 1));
+            assert_eq!(inner.allocate(1), (3, 1));
+            assert_eq!(inner.allocate(1), (4, 1));
+            assert_eq!(inner.allocate(1), (5, 1));
+            assert_eq!(inner.allocate(1), (6, 1));
+            // freelist should be empty so make sure the page is new
+            assert_eq!(inner.meta.num_pages, 10);
+            assert_eq!(inner.allocate(1), (10, 1));
+            assert_eq!(inner.meta.num_pages, 11);
+            assert_eq!(inner.freelist.pages(), vec![]);
+        }
+        Ok(())
+    }
 
-	#[test]
-	fn test_allocate_no_freelist() -> Result<()> {
-		let random_file = RandomFile::new();
-		let db = OpenOptions::new()
-			.pagesize(1024)
-			.num_pages(4)
-			.open(&random_file)?;
-		let tx = db.tx(false)?;
-		let mut tx = tx.inner.borrow_mut();
-		// make sure we have an empty freelist and only four pages
-		assert_eq!(tx.freelist.pages().len(), 0);
-		assert_eq!(tx.meta.num_pages, 4);
-		// allocate one page worth of bytes
-		assert_eq!(tx.allocate(1024), (4, 1));
-		// allocate a half page worth of bytes
-		assert_eq!(tx.allocate(512), (5, 1));
-		// allocate ten pages worth of bytes
-		assert_eq!(tx.allocate(10240), (6, 10));
-		// allocate a non pagesize number of bytes
-		assert_eq!(tx.allocate(1234), (16, 2));
-		Ok(())
-	}
+    #[test]
+    fn test_allocate_no_freelist() -> Result<()> {
+        let random_file = RandomFile::new();
+        let db = OpenOptions::new()
+            .pagesize(1024)
+            .num_pages(4)
+            .open(&random_file)?;
+        let tx = db.tx(false)?;
+        let mut tx = tx.inner.borrow_mut();
+        // make sure we have an empty freelist and only four pages
+        assert_eq!(tx.freelist.pages().len(), 0);
+        assert_eq!(tx.meta.num_pages, 4);
+        // allocate one page worth of bytes
+        assert_eq!(tx.allocate(1024), (4, 1));
+        // allocate a half page worth of bytes
+        assert_eq!(tx.allocate(512), (5, 1));
+        // allocate ten pages worth of bytes
+        assert_eq!(tx.allocate(10240), (6, 10));
+        // allocate a non pagesize number of bytes
+        assert_eq!(tx.allocate(1234), (16, 2));
+        Ok(())
+    }
 
-	#[test]
-	fn test_allocate_freelist() -> Result<()> {
-		let random_file = RandomFile::new();
-		let db = OpenOptions::new()
-			.pagesize(1024)
-			.num_pages(100)
-			.open(&random_file)?;
-		let tx = db.tx(false)?;
-		let mut tx = tx.inner.borrow_mut();
+    #[test]
+    fn test_allocate_freelist() -> Result<()> {
+        let random_file = RandomFile::new();
+        let db = OpenOptions::new()
+            .pagesize(1024)
+            .num_pages(100)
+            .open(&random_file)?;
+        let tx = db.tx(false)?;
+        let mut tx = tx.inner.borrow_mut();
 
-		// setup the freelist and num_pages to simulate a used database
-		for page in [10_u64, 11, 13, 14, 15].iter() {
-			tx.freelist.free(0, *page);
-		}
-		tx.freelist.release(1);
-		tx.meta.num_pages = 99;
+        // setup the freelist and num_pages to simulate a used database
+        for page in [10_u64, 11, 13, 14, 15].iter() {
+            tx.freelist.free(0, *page);
+        }
+        tx.freelist.release(1);
+        tx.meta.num_pages = 99;
 
-		// allocate one page worth of bytes (should come from freelist)
-		assert_eq!(tx.allocate(1024), (10, 1));
-		// allocate a half page worth of bytes (should come from freelist)
-		assert_eq!(tx.allocate(512), (11, 1));
-		// allocate 3 pages worth of bytes (should come from freelist)
-		assert_eq!(tx.allocate(3000), (13, 3));
-		// allocate one byte (freelist should be empty now)
-		assert_eq!(tx.allocate(1), (99, 1));
-		Ok(())
-	}
+        // allocate one page worth of bytes (should come from freelist)
+        assert_eq!(tx.allocate(1024), (10, 1));
+        // allocate a half page worth of bytes (should come from freelist)
+        assert_eq!(tx.allocate(512), (11, 1));
+        // allocate 3 pages worth of bytes (should come from freelist)
+        assert_eq!(tx.allocate(3000), (13, 3));
+        // allocate one byte (freelist should be empty now)
+        assert_eq!(tx.allocate(1), (99, 1));
+        Ok(())
+    }
 
-	#[test]
-	fn test_free() -> Result<()> {
-		let random_file = RandomFile::new();
-		let db = OpenOptions::new()
-			.pagesize(1024)
-			.num_pages(100)
-			.open(&random_file)?;
-		let tx = db.tx(false)?;
-		let mut tx = tx.inner.borrow_mut();
+    #[test]
+    fn test_free() -> Result<()> {
+        let random_file = RandomFile::new();
+        let db = OpenOptions::new()
+            .pagesize(1024)
+            .num_pages(100)
+            .open(&random_file)?;
+        let tx = db.tx(false)?;
+        let mut tx = tx.inner.borrow_mut();
 
-		assert_eq!(tx.meta.tx_id, 0);
-		assert_eq!(tx.freelist.pages().len(), 0);
-		tx.free(80, 1);
-		assert_eq!(tx.freelist.pages(), vec![80]);
-		tx.free(100, 6);
-		assert_eq!(tx.freelist.pages(), vec![80, 100, 101, 102, 103, 104, 105]);
+        assert_eq!(tx.meta.tx_id, 0);
+        assert_eq!(tx.freelist.pages().len(), 0);
+        tx.free(80, 1);
+        assert_eq!(tx.freelist.pages(), vec![80]);
+        tx.free(100, 6);
+        assert_eq!(tx.freelist.pages(), vec![80, 100, 101, 102, 103, 104, 105]);
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	#[test]
-	fn test_copy_data() -> Result<()> {
-		let random_file = RandomFile::new();
-		let db = OpenOptions::new()
-			.pagesize(1024)
-			.num_pages(100)
-			.open(&random_file)?;
-		let tx = db.tx(false)?;
-		let mut tx = tx.inner.borrow_mut();
+    #[test]
+    fn test_copy_data() -> Result<()> {
+        let random_file = RandomFile::new();
+        let db = OpenOptions::new()
+            .pagesize(1024)
+            .num_pages(100)
+            .open(&random_file)?;
+        let tx = db.tx(false)?;
+        let mut tx = tx.inner.borrow_mut();
 
-		let data = vec![1, 2, 3];
-		let parts = tx.copy_data(&data);
-		assert_eq!(parts.slice(), data.as_slice());
-		let data2 = vec![4, 5, 6];
-		let parts2 = tx.copy_data(&data2);
-		assert_eq!(parts.slice(), data.as_slice());
-		assert_eq!(parts2.slice(), data2.as_slice());
-		assert_eq!(tx.buffers.len(), 2);
-		assert_eq!(tx.buffers[0], data);
-		assert_eq!(tx.buffers[1], data2);
-		Ok(())
-	}
+        let data = vec![1, 2, 3];
+        let parts = tx.copy_data(&data);
+        assert_eq!(parts.slice(), data.as_slice());
+        let data2 = vec![4, 5, 6];
+        let parts2 = tx.copy_data(&data2);
+        assert_eq!(parts.slice(), data.as_slice());
+        assert_eq!(parts2.slice(), data2.as_slice());
+        assert_eq!(tx.buffers.len(), 2);
+        assert_eq!(tx.buffers[0], data);
+        assert_eq!(tx.buffers[1], data2);
+        Ok(())
+    }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,32 +1,32 @@
 use rand::{distributions::Alphanumeric, Rng};
 
 pub struct RandomFile {
-	pub path: std::path::PathBuf,
+    pub path: std::path::PathBuf,
 }
 
 impl RandomFile {
-	pub fn new() -> RandomFile {
-		loop {
-			let filename: String = std::str::from_utf8(
-				rand::thread_rng()
-					.sample_iter(&Alphanumeric)
-					.take(30)
-					.collect::<Vec<u8>>()
-					.as_slice(),
-			)
-			.unwrap()
-			.into();
-			let path = std::env::temp_dir().join(filename);
-			if path.metadata().is_err() {
-				return RandomFile { path };
-			}
-		}
-	}
+    pub fn new() -> RandomFile {
+        loop {
+            let filename: String = std::str::from_utf8(
+                rand::thread_rng()
+                    .sample_iter(&Alphanumeric)
+                    .take(30)
+                    .collect::<Vec<u8>>()
+                    .as_slice(),
+            )
+            .unwrap()
+            .into();
+            let path = std::env::temp_dir().join(filename);
+            if path.metadata().is_err() {
+                return RandomFile { path };
+            }
+        }
+    }
 }
 
 impl Drop for RandomFile {
-	#[allow(unused_must_use)]
-	fn drop(&mut self) {
-		std::fs::remove_file(&self.path);
-	}
+    #[allow(unused_must_use)]
+    fn drop(&mut self) {
+        std::fs::remove_file(&self.path);
+    }
 }

--- a/tests/deletes.rs
+++ b/tests/deletes.rs
@@ -6,151 +6,151 @@ mod common;
 
 #[test]
 fn small_deletes() {
-	for _ in 0..10 {
-		test_deletes(100).unwrap();
-	}
+    for _ in 0..10 {
+        test_deletes(100).unwrap();
+    }
 }
 
 #[test]
 fn medium_deletes() {
-	for _ in 0..10 {
-		test_deletes(1000).unwrap();
-	}
+    for _ in 0..10 {
+        test_deletes(1000).unwrap();
+    }
 }
 
 #[test]
 fn large_deletes() {
-	for _ in 0..10 {
-		test_deletes(1000).unwrap();
-	}
+    for _ in 0..10 {
+        test_deletes(1000).unwrap();
+    }
 }
 
 fn test_deletes(highest_int: u64) -> Result<(), Error> {
-	let random_file = common::RandomFile::new();
-	let mut deleted = HashSet::new();
-	let mut rng = rand::thread_rng();
-	{
-		let db = DB::open(&random_file.path)?;
-		{
-			let tx = db.tx(true)?;
-			let b = tx.create_bucket("abc")?;
-			for i in 0..highest_int {
-				b.put(i.to_be_bytes(), i.to_string())?;
-			}
-			tx.commit()?;
-		}
-		let mut ids_to_delete: Vec<u64> = (0..highest_int).collect();
-		ids_to_delete.shuffle(&mut rng);
-		let mut id_iter = ids_to_delete.iter();
+    let random_file = common::RandomFile::new();
+    let mut deleted = HashSet::new();
+    let mut rng = rand::thread_rng();
+    {
+        let db = DB::open(&random_file.path)?;
+        {
+            let tx = db.tx(true)?;
+            let b = tx.create_bucket("abc")?;
+            for i in 0..highest_int {
+                b.put(i.to_be_bytes(), i.to_string())?;
+            }
+            tx.commit()?;
+        }
+        let mut ids_to_delete: Vec<u64> = (0..highest_int).collect();
+        ids_to_delete.shuffle(&mut rng);
+        let mut id_iter = ids_to_delete.iter();
 
-		loop {
-			{
-				let tx = db.tx(true)?;
-				let b = tx.get_bucket("abc")?;
-				// delete between 0 and 100 random items
-				for _ in 0..rng.gen_range(10..=100) {
-					let i = id_iter.next();
-					if i.is_none() {
-						break;
-					}
-					let i = i.unwrap();
-					if deleted.insert(i) {
-						let kv = b.delete(i.to_be_bytes())?;
-						assert_eq!(kv.key(), i.to_be_bytes());
-						assert_eq!(kv.value(), i.to_string().as_bytes());
-					}
-				}
-				for i in 0..highest_int {
-					let data = b.get(i.to_be_bytes());
-					if deleted.contains(&i) {
-						assert_eq!(data, None)
-					} else {
-						let data = data.unwrap();
-						let kv = data.kv();
-						assert_eq!(kv.key(), i.to_be_bytes());
-						assert_eq!(kv.value(), i.to_string().as_bytes());
-					}
-				}
-				tx.commit()?;
-			}
-			{
-				let tx = db.tx(true)?;
-				let b = tx.get_bucket("abc")?;
-				for i in 0..highest_int {
-					let data = b.get(i.to_be_bytes());
-					if deleted.contains(&i) {
-						assert_eq!(data, None)
-					} else {
-						let data = data.unwrap();
-						let kv = data.kv();
-						assert_eq!(kv.key(), i.to_be_bytes());
-						assert_eq!(kv.value(), i.to_string().as_bytes());
-					}
-				}
-			}
-			if deleted.len() == ids_to_delete.len() {
-				break;
-			}
-		}
-		db.check()
-	}
+        loop {
+            {
+                let tx = db.tx(true)?;
+                let b = tx.get_bucket("abc")?;
+                // delete between 0 and 100 random items
+                for _ in 0..rng.gen_range(10..=100) {
+                    let i = id_iter.next();
+                    if i.is_none() {
+                        break;
+                    }
+                    let i = i.unwrap();
+                    if deleted.insert(i) {
+                        let kv = b.delete(i.to_be_bytes())?;
+                        assert_eq!(kv.key(), i.to_be_bytes());
+                        assert_eq!(kv.value(), i.to_string().as_bytes());
+                    }
+                }
+                for i in 0..highest_int {
+                    let data = b.get(i.to_be_bytes());
+                    if deleted.contains(&i) {
+                        assert_eq!(data, None)
+                    } else {
+                        let data = data.unwrap();
+                        let kv = data.kv();
+                        assert_eq!(kv.key(), i.to_be_bytes());
+                        assert_eq!(kv.value(), i.to_string().as_bytes());
+                    }
+                }
+                tx.commit()?;
+            }
+            {
+                let tx = db.tx(true)?;
+                let b = tx.get_bucket("abc")?;
+                for i in 0..highest_int {
+                    let data = b.get(i.to_be_bytes());
+                    if deleted.contains(&i) {
+                        assert_eq!(data, None)
+                    } else {
+                        let data = data.unwrap();
+                        let kv = data.kv();
+                        assert_eq!(kv.key(), i.to_be_bytes());
+                        assert_eq!(kv.value(), i.to_string().as_bytes());
+                    }
+                }
+            }
+            if deleted.len() == ids_to_delete.len() {
+                break;
+            }
+        }
+        db.check()
+    }
 }
 
 #[test]
 fn delete_simple_bucket() -> Result<(), Error> {
-	let random_file = common::RandomFile::new();
-	let db = DB::open(&random_file.path)?;
-	{
-		let tx = db.tx(true)?;
-		let b = tx.create_bucket("abc")?;
-		for i in 0..10_u64 {
-			b.put(i.to_be_bytes(), i.to_string())?;
-		}
-		tx.commit()?;
-	}
-	{
-		let tx = db.tx(true)?;
-		tx.delete_bucket("abc")?;
-		assert_eq!(tx.get_bucket("abc").err(), Some(Error::BucketMissing));
-		// delete a freshly created bucket
-		let b = tx.create_bucket("def")?;
-		b.put("some", "data")?;
-		tx.delete_bucket("def")?;
+    let random_file = common::RandomFile::new();
+    let db = DB::open(&random_file.path)?;
+    {
+        let tx = db.tx(true)?;
+        let b = tx.create_bucket("abc")?;
+        for i in 0..10_u64 {
+            b.put(i.to_be_bytes(), i.to_string())?;
+        }
+        tx.commit()?;
+    }
+    {
+        let tx = db.tx(true)?;
+        tx.delete_bucket("abc")?;
+        assert_eq!(tx.get_bucket("abc").err(), Some(Error::BucketMissing));
+        // delete a freshly created bucket
+        let b = tx.create_bucket("def")?;
+        b.put("some", "data")?;
+        tx.delete_bucket("def")?;
 
-		tx.commit()?;
-	}
-	{
-		let tx = db.tx(false)?;
-		assert_eq!(tx.get_bucket("abc").err(), Some(Error::BucketMissing));
-		assert_eq!(tx.get_bucket("def").err(), Some(Error::BucketMissing));
-	}
-	db.check()
+        tx.commit()?;
+    }
+    {
+        let tx = db.tx(false)?;
+        assert_eq!(tx.get_bucket("abc").err(), Some(Error::BucketMissing));
+        assert_eq!(tx.get_bucket("def").err(), Some(Error::BucketMissing));
+    }
+    db.check()
 }
 
 #[test]
 fn delete_large_bucket_with_large_nested_buckets() -> Result<(), Error> {
-	let random_file = common::RandomFile::new();
-	let db = DB::open(&random_file.path)?;
-	{
-		let tx = db.tx(true)?;
-		let b = tx.create_bucket("abc")?;
-		for i in 0..50_u64 {
-			let sub_bucket = b.create_bucket(i.to_be_bytes())?;
-			for i in 0..1000_u64 {
-				sub_bucket.put(i.to_be_bytes(), i.to_string().repeat(10))?;
-			}
-		}
-		tx.commit()?;
-	}
-	{
-		let tx = db.tx(true)?;
-		tx.delete_bucket("abc")?;
-		assert_eq!(tx.get_bucket("abc").err(), Some(Error::BucketMissing));
-		tx.commit()?;
-	}
-	{
-		let tx = db.tx(false)?;
-		assert_eq!(tx.get_bucket("abc").err(), Some(Error::BucketMissing));
-	}
-	db.check()
+    let random_file = common::RandomFile::new();
+    let db = DB::open(&random_file.path)?;
+    {
+        let tx = db.tx(true)?;
+        let b = tx.create_bucket("abc")?;
+        for i in 0..50_u64 {
+            let sub_bucket = b.create_bucket(i.to_be_bytes())?;
+            for i in 0..1000_u64 {
+                sub_bucket.put(i.to_be_bytes(), i.to_string().repeat(10))?;
+            }
+        }
+        tx.commit()?;
+    }
+    {
+        let tx = db.tx(true)?;
+        tx.delete_bucket("abc")?;
+        assert_eq!(tx.get_bucket("abc").err(), Some(Error::BucketMissing));
+        tx.commit()?;
+    }
+    {
+        let tx = db.tx(false)?;
+        assert_eq!(tx.get_bucket("abc").err(), Some(Error::BucketMissing));
+    }
+    db.check()
 }

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -5,208 +5,277 @@ mod common;
 
 #[test]
 fn cursor_seek() -> Result<(), Error> {
-	// list from https://simple.wikipedia.org/wiki/List_of_fruits
-	let mut fruits = vec![
-		"açaí",
-		"ackee",
-		"apple",
-		"apricot",
-		"avocado",
-		"banana",
-		"bilberry",
-		"black sapote",
-		"blackberry",
-		"blackcurrant",
-		"blood orange",
-		"blueberry",
-		"boysenberry",
-		"breadfruit",
-		"cactus pear",
-		"cantaloupe",
-		"cherimoya",
-		"cherry",
-		"chico fruit",
-		"clementine",
-		"cloudberry",
-		"coconut",
-		"crab apple",
-		"cranberry",
-		"currant",
-		"damson",
-		"date",
-		"dragonfruit",
-		"durian",
-		"elderberry",
-		"feijoa",
-		"fig",
-		"galia melon",
-		"goji berry",
-		"gooseberry",
-		"grape",
-		"grapefruit",
-		"guava",
-		"hala fruit",
-		"honeyberry",
-		"honeydew",
-		"huckleberry",
-		"jabuticaba",
-		"jackfruit",
-		"jambul",
-		"japanese plum",
-		"jostaberry",
-		"jujube",
-		"juniper berry",
-		"kiwano",
-		"kiwifruit",
-		"kumquat",
-		"lemon",
-		"lime",
-		"loganberry",
-		"longan",
-		"loquat",
-		"lychee",
-		"mandarine",
-		"mango",
-		"mangosteen",
-		"marionberry",
-		"melon",
-		"miracle fruit",
-		"monstera delisiousa",
-		"mulberry",
-		"nance",
-		"nectarine",
-		"orange",
-		"papaya",
-		"passionfruit",
-		"peach",
-		"pear",
-		"persimmon",
-		"pineapple",
-		"pineberry",
-		"plantain",
-		"plum",
-		"plumcot",
-		"pomegranate",
-		"pomelo",
-		"prune",
-		"purple mangosteen",
-		"quince",
-		"raisin",
-		"rambutan",
-		"raspberry",
-		"redcurrant",
-		"salak",
-		"salal berry",
-		"salmonberry",
-		"satsuma",
-		"soursop",
-		"star apple",
-		"star fruit",
-		"strawberry",
-		"surinam cherry",
-		"tamarillo",
-		"tamarind",
-		"tangelo",
-		"tangerine",
-		"tayberry",
-		"ugli fruit",
-		"watermelon",
-		"white currant",
-		"white sapote",
-		"yuzu",
-	];
-	fruits.sort_unstable();
+    // list from https://simple.wikipedia.org/wiki/List_of_fruits
+    let mut fruits = vec![
+        "açaí",
+        "ackee",
+        "apple",
+        "apricot",
+        "avocado",
+        "banana",
+        "bilberry",
+        "black sapote",
+        "blackberry",
+        "blackcurrant",
+        "blood orange",
+        "blueberry",
+        "boysenberry",
+        "breadfruit",
+        "cactus pear",
+        "cantaloupe",
+        "cherimoya",
+        "cherry",
+        "chico fruit",
+        "clementine",
+        "cloudberry",
+        "coconut",
+        "crab apple",
+        "cranberry",
+        "currant",
+        "damson",
+        "date",
+        "dragonfruit",
+        "durian",
+        "elderberry",
+        "feijoa",
+        "fig",
+        "galia melon",
+        "goji berry",
+        "gooseberry",
+        "grape",
+        "grapefruit",
+        "guava",
+        "hala fruit",
+        "honeyberry",
+        "honeydew",
+        "huckleberry",
+        "jabuticaba",
+        "jackfruit",
+        "jambul",
+        "japanese plum",
+        "jostaberry",
+        "jujube",
+        "juniper berry",
+        "kiwano",
+        "kiwifruit",
+        "kumquat",
+        "lemon",
+        "lime",
+        "loganberry",
+        "longan",
+        "loquat",
+        "lychee",
+        "mandarine",
+        "mango",
+        "mangosteen",
+        "marionberry",
+        "melon",
+        "miracle fruit",
+        "monstera delisiousa",
+        "mulberry",
+        "nance",
+        "nectarine",
+        "orange",
+        "papaya",
+        "passionfruit",
+        "peach",
+        "pear",
+        "persimmon",
+        "pineapple",
+        "pineberry",
+        "plantain",
+        "plum",
+        "plumcot",
+        "pomegranate",
+        "pomelo",
+        "prune",
+        "purple mangosteen",
+        "quince",
+        "raisin",
+        "rambutan",
+        "raspberry",
+        "redcurrant",
+        "salak",
+        "salal berry",
+        "salmonberry",
+        "satsuma",
+        "soursop",
+        "star apple",
+        "star fruit",
+        "strawberry",
+        "surinam cherry",
+        "tamarillo",
+        "tamarind",
+        "tangelo",
+        "tangerine",
+        "tayberry",
+        "ugli fruit",
+        "watermelon",
+        "white currant",
+        "white sapote",
+        "yuzu",
+    ];
+    fruits.sort_unstable();
 
-	let random_file = common::RandomFile::new();
-	{
-		let db = DB::open(&random_file.path)?;
-		{
-			let tx = db.tx(true)?;
-			let b = tx.create_bucket("abc")?;
-			{
-				let mut random_fruits = Vec::from(fruits.as_slice());
-				let mut rng = rand::thread_rng();
-				random_fruits.shuffle(&mut rng);
-				// randomly insert the fruits into the bucket
-				for fruit in random_fruits.iter() {
-					let index = fruits.binary_search(fruit).unwrap();
-					b.put(fruit, index.to_string())?;
-				}
-			}
-			check_cursor_starts(&fruits, &b);
-			tx.commit()?;
-		}
-		{
-			let tx = db.tx(false)?;
-			let b = tx.get_bucket("abc")?;
-			check_cursor_starts(&fruits, &b);
-		}
-	}
-	{
-		let db = DB::open(&random_file.path)?;
-		{
-			let tx = db.tx(false)?;
-			let b = tx.get_bucket("abc")?;
-			check_cursor_starts(&fruits, &b);
-		}
-		{
-			let tx = db.tx(false)?;
-			let b = tx.get_bucket("abc")?;
-			println!("7 {} {:?}", fruits[7], &fruits[7..]);
-			check_cursor("bl", &fruits[6..], &b, 6);
-		}
-		{
-			let tx = db.tx(true)?;
-			let b = tx.get_bucket("abc")?;
-			b.put("zomato", fruits.len().to_string())?;
-			fruits.push("zomato");
-			check_cursor_starts(&fruits, &b);
-			tx.commit()?;
-		}
-		{
-			let tx = db.tx(false)?;
-			let mut b = tx.get_bucket("abc")?;
-			println!("7 {} {:?}", fruits[7], &fruits[7..]);
-			check_cursor("bl", &fruits[6..], &mut b, 6);
-		}
-	}
-	let db = DB::open(&random_file.path)?;
-	db.check()
+    let random_file = common::RandomFile::new();
+    {
+        let db = DB::open(&random_file.path)?;
+        {
+            let tx = db.tx(true)?;
+            let b = tx.create_bucket("abc")?;
+            {
+                let mut random_fruits = Vec::from(fruits.as_slice());
+                let mut rng = rand::thread_rng();
+                random_fruits.shuffle(&mut rng);
+                // randomly insert the fruits into the bucket
+                for fruit in random_fruits.iter() {
+                    let index = fruits.binary_search(fruit).unwrap();
+                    b.put(fruit, index.to_string())?;
+                }
+            }
+            check_cursor_starts(&fruits, &b);
+            tx.commit()?;
+        }
+        {
+            let tx = db.tx(false)?;
+            let b = tx.get_bucket("abc")?;
+            check_cursor_starts(&fruits, &b);
+        }
+    }
+    {
+        let db = DB::open(&random_file.path)?;
+        {
+            let tx = db.tx(false)?;
+            let b = tx.get_bucket("abc")?;
+            check_cursor_starts(&fruits, &b);
+        }
+        {
+            let tx = db.tx(false)?;
+            let b = tx.get_bucket("abc")?;
+            println!("7 {} {:?}", fruits[7], &fruits[7..]);
+            check_cursor("bl", &fruits[6..], &b, 6);
+        }
+        {
+            let tx = db.tx(true)?;
+            let b = tx.get_bucket("abc")?;
+            b.put("zomato", fruits.len().to_string())?;
+            fruits.push("zomato");
+            check_cursor_starts(&fruits, &b);
+            tx.commit()?;
+        }
+        {
+            let tx = db.tx(false)?;
+            let mut b = tx.get_bucket("abc")?;
+            println!("7 {} {:?}", fruits[7], &fruits[7..]);
+            check_cursor("bl", &fruits[6..], &mut b, 6);
+        }
+    }
+    let db = DB::open(&random_file.path)?;
+    db.check()
 }
 
 // checks every start position and checks that you can iterate
 // starting from there
 fn check_cursor_starts(fruits: &Vec<&str>, b: &Bucket) {
-	// randomly seek over the bucket
-	let mut random_fruits = Vec::from(fruits.as_slice());
-	let mut rng = rand::thread_rng();
-	random_fruits.shuffle(&mut rng);
-	for fruit in random_fruits.iter() {
-		let start_index = fruits.binary_search(fruit).unwrap();
-		let expected_fruits = &fruits[start_index..];
-		check_cursor(fruit, expected_fruits, b, start_index);
-	}
+    // randomly seek over the bucket
+    let mut random_fruits = Vec::from(fruits.as_slice());
+    let mut rng = rand::thread_rng();
+    random_fruits.shuffle(&mut rng);
+    for fruit in random_fruits.iter() {
+        let start_index = fruits.binary_search(fruit).unwrap();
+        let expected_fruits = &fruits[start_index..];
+        check_cursor(fruit, expected_fruits, b, start_index);
+    }
 }
 
 fn check_cursor(seek_to: &str, expected_fruits: &[&str], b: &Bucket, start_index: usize) {
-	let mut cur_index = 0;
-	let mut cursor = b.cursor();
-	let exists = cursor.seek(seek_to);
-	if expected_fruits[0] == seek_to {
-		assert!(exists);
-	}
-	for data in cursor {
-		assert!(cur_index < expected_fruits.len());
-		let expected_fruit = expected_fruits[cur_index];
-		if let Data::KeyValue(kv) = &*data {
-			println!("KEY {}", std::str::from_utf8(kv.key()).unwrap());
-			assert_eq!(expected_fruit.as_bytes(), kv.key());
-			let value_string = (cur_index + start_index).to_string();
-			assert_eq!(value_string.as_bytes(), kv.value());
-		} else {
-			panic!("Expected Data::KeyValue");
-		}
-		cur_index += 1;
-	}
-	assert_eq!(cur_index, expected_fruits.len());
+    let mut cur_index = 0;
+    let mut cursor = b.cursor();
+    let exists = cursor.seek(seek_to);
+    if expected_fruits[0] == seek_to {
+        assert!(exists);
+    }
+    for data in cursor {
+        assert!(cur_index < expected_fruits.len());
+        let expected_fruit = expected_fruits[cur_index];
+        if let Data::KeyValue(kv) = &*data {
+            println!("KEY {}", std::str::from_utf8(kv.key()).unwrap());
+            assert_eq!(expected_fruit.as_bytes(), kv.key());
+            let value_string = (cur_index + start_index).to_string();
+            assert_eq!(value_string.as_bytes(), kv.value());
+        } else {
+            panic!("Expected Data::KeyValue");
+        }
+        cur_index += 1;
+    }
+    assert_eq!(cur_index, expected_fruits.len());
+}
+
+#[test]
+fn root_buckets() -> Result<(), Error> {
+    let random_file = common::RandomFile::new();
+    {
+        let db = DB::open(&random_file.path)?;
+        {
+            let tx = db.tx(true)?;
+            {
+                let b = tx.create_bucket("abc")?;
+                b.put("data", "one")?;
+            }
+            {
+                let b = tx.create_bucket("def")?;
+                b.put("data", "two")?;
+            }
+            {
+                let b = tx.create_bucket("ghi")?;
+                b.put("data", "three")?;
+            }
+            tx.commit()?;
+        }
+        let tx = db.tx(false)?;
+        for (i, (data, bucket)) in tx.buckets().enumerate() {
+            let name = std::str::from_utf8(data.name()).unwrap();
+            let kv = bucket.get_kv("data").unwrap();
+            let value = std::str::from_utf8(kv.value()).unwrap();
+            if i == 0 {
+                assert_eq!(name, "abc");
+                assert_eq!(value, "one");
+            } else if i == 1 {
+                assert_eq!(name, "def");
+                assert_eq!(value, "two");
+            } else if i == 2 {
+                assert_eq!(name, "ghi");
+                assert_eq!(value, "three");
+            } else {
+                panic!("TOO MANY BUCKETS!")
+            }
+        }
+    };
+    Ok(())
+}
+
+#[test]
+fn kv_iter() -> Result<(), Error> {
+    let random_file = common::RandomFile::new();
+    let data = vec![("abc", "one"), ("def", "two"), ("ghi", "three")];
+    {
+        let db = DB::open(&random_file.path)?;
+        {
+            let tx = db.tx(true)?;
+            {
+                let b = tx.create_bucket("data")?;
+                for (k, v) in data.iter() {
+                    b.put(k, v)?;
+                }
+            }
+            tx.commit()?;
+        }
+        let tx = db.tx(false)?;
+        let b = tx.get_bucket("data")?;
+        for ((k, v), kvpair) in data.into_iter().zip(b.kv_pairs()) {
+            assert_eq!(k.as_bytes(), kvpair.key());
+            assert_eq!(v.as_bytes(), kvpair.value());
+        }
+    };
+    Ok(())
 }

--- a/tests/multiple_buckets.rs
+++ b/tests/multiple_buckets.rs
@@ -4,135 +4,135 @@ mod common;
 
 #[test]
 fn sibling_buckets() -> Result<(), Error> {
-	let random_file = common::RandomFile::new();
-	{
-		let db = DB::open(&random_file.path)?;
-		{
-			let tx = db.tx(true)?;
-			let b = tx.create_bucket("abc")?;
-			for i in 0..=10_u64 {
-				let existing = b.put(i.to_be_bytes(), i.to_string())?;
-				assert!(existing.is_none());
-			}
-			check_data(&b, 11, 1, vec![]);
-			assert_eq!(b.next_int(), 11);
-			tx.commit()?;
-		}
-		{
-			let tx = db.tx(true)?;
+    let random_file = common::RandomFile::new();
+    {
+        let db = DB::open(&random_file.path)?;
+        {
+            let tx = db.tx(true)?;
+            let b = tx.create_bucket("abc")?;
+            for i in 0..=10_u64 {
+                let existing = b.put(i.to_be_bytes(), i.to_string())?;
+                assert!(existing.is_none());
+            }
+            check_data(&b, 11, 1, vec![]);
+            assert_eq!(b.next_int(), 11);
+            tx.commit()?;
+        }
+        {
+            let tx = db.tx(true)?;
 
-			let b = tx.get_bucket("abc")?;
-			check_data(&b, 11, 1, vec![]);
-			for i in 0..=10_u64 {
-				let existing = b.put(i.to_be_bytes(), i.to_string().repeat(4))?;
-				assert!(existing.is_some());
-				let kv = existing.unwrap();
-				assert_eq!(kv.key(), i.to_be_bytes());
-				assert_eq!(kv.value(), i.to_string().as_bytes());
-			}
-			check_data(&b, 11, 4, vec![]);
-			assert_eq!(b.next_int(), 11);
-			let b2 = tx.create_bucket("def")?;
-			for i in 0..=900_u64 {
-				b2.put(i.to_be_bytes(), i.to_string().repeat(2))?;
-			}
-			check_data(&b2, 901, 2, vec![]);
-			assert_eq!(b2.next_int(), 901);
-			tx.commit()?;
-		}
-		{
-			let tx = db.tx(true)?;
-			let b = tx.get_bucket("abc")?;
-			check_data(&b, 11, 4, vec![]);
-			assert_eq!(b.next_int(), 11);
+            let b = tx.get_bucket("abc")?;
+            check_data(&b, 11, 1, vec![]);
+            for i in 0..=10_u64 {
+                let existing = b.put(i.to_be_bytes(), i.to_string().repeat(4))?;
+                assert!(existing.is_some());
+                let kv = existing.unwrap();
+                assert_eq!(kv.key(), i.to_be_bytes());
+                assert_eq!(kv.value(), i.to_string().as_bytes());
+            }
+            check_data(&b, 11, 4, vec![]);
+            assert_eq!(b.next_int(), 11);
+            let b2 = tx.create_bucket("def")?;
+            for i in 0..=900_u64 {
+                b2.put(i.to_be_bytes(), i.to_string().repeat(2))?;
+            }
+            check_data(&b2, 901, 2, vec![]);
+            assert_eq!(b2.next_int(), 901);
+            tx.commit()?;
+        }
+        {
+            let tx = db.tx(true)?;
+            let b = tx.get_bucket("abc")?;
+            check_data(&b, 11, 4, vec![]);
+            assert_eq!(b.next_int(), 11);
 
-			let b2 = tx.get_bucket("def")?;
-			check_data(&b2, 901, 2, vec![]);
-			assert_eq!(b2.next_int(), 901);
-		}
-	}
-	{
-		let db = DB::open(&random_file.path)?;
-		let tx = db.tx(true)?;
-		{
-			let b = tx.get_bucket("abc")?;
-			check_data(&b, 11, 4, vec![]);
-		}
-		{
-			let b2 = tx.get_bucket("def")?;
-			check_data(&b2, 901, 2, vec![]);
-		}
-	}
-	let db = DB::open(&random_file.path)?;
-	db.check()
+            let b2 = tx.get_bucket("def")?;
+            check_data(&b2, 901, 2, vec![]);
+            assert_eq!(b2.next_int(), 901);
+        }
+    }
+    {
+        let db = DB::open(&random_file.path)?;
+        let tx = db.tx(true)?;
+        {
+            let b = tx.get_bucket("abc")?;
+            check_data(&b, 11, 4, vec![]);
+        }
+        {
+            let b2 = tx.get_bucket("def")?;
+            check_data(&b2, 901, 2, vec![]);
+        }
+    }
+    let db = DB::open(&random_file.path)?;
+    db.check()
 }
 
 #[test]
 fn nested_buckets() -> Result<(), Error> {
-	let random_file = common::RandomFile::new();
-	{
-		let db = DB::open(&random_file.path)?;
-		{
-			let tx = db.tx(true)?;
-			let b = tx.create_bucket("abc")?;
-			for i in 0..=10_u64 {
-				let existing = b.put(i.to_be_bytes(), i.to_string().repeat(2))?;
-				assert!(existing.is_none());
-			}
-			assert_eq!(b.next_int(), 11);
-			check_data(&b, 11, 2, vec![]);
-			let b = b.create_bucket("def")?;
-			for i in 0..=100_u64 {
-				let existing = b.put(i.to_be_bytes(), i.to_string().repeat(4))?;
-				assert!(existing.is_none());
-			}
-			assert_eq!(b.next_int(), 101);
-			check_data(&b, 101, 4, vec![]);
-			let b = b.create_bucket("ghi")?;
-			for i in 0..=1000_u64 {
-				let existing = b.put(i.to_be_bytes(), i.to_string().repeat(8))?;
-				assert!(existing.is_none());
-			}
-			assert_eq!(b.next_int(), 1001);
-			check_data(&b, 1001, 8, vec![]);
-			tx.commit()?;
-		}
-		{
-			let tx = db.tx(true)?;
+    let random_file = common::RandomFile::new();
+    {
+        let db = DB::open(&random_file.path)?;
+        {
+            let tx = db.tx(true)?;
+            let b = tx.create_bucket("abc")?;
+            for i in 0..=10_u64 {
+                let existing = b.put(i.to_be_bytes(), i.to_string().repeat(2))?;
+                assert!(existing.is_none());
+            }
+            assert_eq!(b.next_int(), 11);
+            check_data(&b, 11, 2, vec![]);
+            let b = b.create_bucket("def")?;
+            for i in 0..=100_u64 {
+                let existing = b.put(i.to_be_bytes(), i.to_string().repeat(4))?;
+                assert!(existing.is_none());
+            }
+            assert_eq!(b.next_int(), 101);
+            check_data(&b, 101, 4, vec![]);
+            let b = b.create_bucket("ghi")?;
+            for i in 0..=1000_u64 {
+                let existing = b.put(i.to_be_bytes(), i.to_string().repeat(8))?;
+                assert!(existing.is_none());
+            }
+            assert_eq!(b.next_int(), 1001);
+            check_data(&b, 1001, 8, vec![]);
+            tx.commit()?;
+        }
+        {
+            let tx = db.tx(true)?;
 
-			let b = tx.get_bucket("abc")?;
-			check_data(&b, 12, 2, vec![Vec::from("def".as_bytes())]);
-			assert_eq!(b.next_int(), 12);
+            let b = tx.get_bucket("abc")?;
+            check_data(&b, 12, 2, vec![Vec::from("def".as_bytes())]);
+            assert_eq!(b.next_int(), 12);
 
-			let b = b.get_bucket("def")?;
-			check_data(&b, 102, 4, vec![Vec::from("ghi".as_bytes())]);
-			assert_eq!(b.next_int(), 102);
+            let b = b.get_bucket("def")?;
+            check_data(&b, 102, 4, vec![Vec::from("ghi".as_bytes())]);
+            assert_eq!(b.next_int(), 102);
 
-			let b = b.get_bucket("ghi")?;
-			check_data(&b, 1001, 8, vec![]);
-			assert_eq!(b.next_int(), 1001);
+            let b = b.get_bucket("ghi")?;
+            check_data(&b, 1001, 8, vec![]);
+            assert_eq!(b.next_int(), 1001);
 
-			tx.commit()?;
-		}
-	}
-	let db = DB::open(&random_file.path)?;
-	db.check()
+            tx.commit()?;
+        }
+    }
+    let db = DB::open(&random_file.path)?;
+    db.check()
 }
 
 fn check_data(b: &Bucket, len: u64, repeats: usize, bucket_names: Vec<Vec<u8>>) {
-	let mut count: u64 = 0;
-	for (i, data) in b.cursor().into_iter().enumerate() {
-		let i = i as u64;
-		count += 1;
-		match &*data {
-			Data::KeyValue(kv) => {
-				assert_eq!(kv.key(), i.to_be_bytes());
-				assert_eq!(kv.value(), i.to_string().repeat(repeats).as_bytes());
-			}
-			Data::Bucket(b) => {
-				assert!(bucket_names.contains(&Vec::from(b.name())));
-			}
-		};
-	}
-	assert_eq!(count, len);
+    let mut count: u64 = 0;
+    for (i, data) in b.cursor().into_iter().enumerate() {
+        let i = i as u64;
+        count += 1;
+        match &*data {
+            Data::KeyValue(kv) => {
+                assert_eq!(kv.key(), i.to_be_bytes());
+                assert_eq!(kv.value(), i.to_string().repeat(repeats).as_bytes());
+            }
+            Data::Bucket(b) => {
+                assert!(bucket_names.contains(&Vec::from(b.name())));
+            }
+        };
+    }
+    assert_eq!(count, len);
 }

--- a/tests/multiple_txs.rs
+++ b/tests/multiple_txs.rs
@@ -4,72 +4,72 @@ mod common;
 
 #[test]
 fn tx_isolation() -> Result<(), Error> {
-	let random_file = common::RandomFile::new();
-	let db = DB::open(&random_file.path)?;
-	{
-		let ro_tx = db.tx(false)?;
-		let wr_tx = db.tx(true)?;
-		let b = wr_tx.create_bucket("abc123")?;
+    let random_file = common::RandomFile::new();
+    let db = DB::open(&random_file.path)?;
+    {
+        let ro_tx = db.tx(false)?;
+        let wr_tx = db.tx(true)?;
+        let b = wr_tx.create_bucket("abc123")?;
 
-		for i in 0..=10_u64 {
-			assert_eq!(b.next_int(), i);
-			assert!((b.put(i.to_be_bytes(), i.to_string())?).is_none());
-		}
-		assert_eq!(b.next_int(), 11);
+        for i in 0..=10_u64 {
+            assert_eq!(b.next_int(), i);
+            assert!((b.put(i.to_be_bytes(), i.to_string())?).is_none());
+        }
+        assert_eq!(b.next_int(), 11);
 
-		if let Err(e) = ro_tx.get_bucket("abc123") {
-			match e {
-				Error::BucketMissing => (),
-				_ => panic!("Unexpected error {:?}", e),
-			}
-		} else {
-			panic!("Expected err");
-		}
-		wr_tx.commit()?;
-	}
-	{
-		let ro_tx = db.tx(false)?;
-		let ro_b = ro_tx.get_bucket("abc123")?;
-		check_data(&ro_b, 11, 1);
-		let rw_tx = db.tx(true)?;
-		let rw_b = rw_tx.get_bucket("abc123")?;
-		check_data(&rw_b, 11, 1);
-		assert_eq!(ro_b.next_int(), 11);
-		assert_eq!(rw_b.next_int(), 11);
-		for i in 0..=100_u64 {
-			let next_int = rw_b.next_int();
-			let existing_data = rw_b.put(i.to_be_bytes(), i.to_string().repeat(4))?;
-			if i < 11 {
-				assert_eq!(next_int, 11);
-				assert!(existing_data.is_some());
-				let kv = existing_data.unwrap();
-				assert_eq!(kv.key(), i.to_be_bytes());
-				assert_eq!(kv.value(), i.to_string().as_bytes());
-			} else {
-				assert_eq!(next_int, i);
-				assert!(existing_data.is_none());
-			}
-			assert_eq!(ro_b.next_int(), 11);
-		}
-		assert_eq!(rw_b.next_int(), 101);
-		check_data(&rw_b, 101, 4);
-		check_data(&ro_b, 11, 1);
-	}
-	db.check()
+        if let Err(e) = ro_tx.get_bucket("abc123") {
+            match e {
+                Error::BucketMissing => (),
+                _ => panic!("Unexpected error {:?}", e),
+            }
+        } else {
+            panic!("Expected err");
+        }
+        wr_tx.commit()?;
+    }
+    {
+        let ro_tx = db.tx(false)?;
+        let ro_b = ro_tx.get_bucket("abc123")?;
+        check_data(&ro_b, 11, 1);
+        let rw_tx = db.tx(true)?;
+        let rw_b = rw_tx.get_bucket("abc123")?;
+        check_data(&rw_b, 11, 1);
+        assert_eq!(ro_b.next_int(), 11);
+        assert_eq!(rw_b.next_int(), 11);
+        for i in 0..=100_u64 {
+            let next_int = rw_b.next_int();
+            let existing_data = rw_b.put(i.to_be_bytes(), i.to_string().repeat(4))?;
+            if i < 11 {
+                assert_eq!(next_int, 11);
+                assert!(existing_data.is_some());
+                let kv = existing_data.unwrap();
+                assert_eq!(kv.key(), i.to_be_bytes());
+                assert_eq!(kv.value(), i.to_string().as_bytes());
+            } else {
+                assert_eq!(next_int, i);
+                assert!(existing_data.is_none());
+            }
+            assert_eq!(ro_b.next_int(), 11);
+        }
+        assert_eq!(rw_b.next_int(), 101);
+        check_data(&rw_b, 101, 4);
+        check_data(&ro_b, 11, 1);
+    }
+    db.check()
 }
 
 fn check_data(b: &Bucket, len: u64, repeats: usize) {
-	let mut count: u64 = 0;
-	for (i, data) in b.cursor().into_iter().enumerate() {
-		let i = i as u64;
-		count += 1;
-		match &*data {
-			Data::KeyValue(kv) => {
-				assert_eq!(kv.key(), i.to_be_bytes());
-				assert_eq!(kv.value(), i.to_string().repeat(repeats).as_bytes());
-			}
-			_ => panic!("Expected Data::KeyValue"),
-		};
-	}
-	assert_eq!(count, len);
+    let mut count: u64 = 0;
+    for (i, data) in b.cursor().into_iter().enumerate() {
+        let i = i as u64;
+        count += 1;
+        match &*data {
+            Data::KeyValue(kv) => {
+                assert_eq!(kv.key(), i.to_be_bytes());
+                assert_eq!(kv.value(), i.to_string().repeat(repeats).as_bytes());
+            }
+            _ => panic!("Expected Data::KeyValue"),
+        };
+    }
+    assert_eq!(count, len);
 }

--- a/tests/simple_inserts.rs
+++ b/tests/simple_inserts.rs
@@ -5,81 +5,81 @@ mod common;
 
 #[test]
 fn small_insert() -> Result<(), Error> {
-	test_insert((0..=100).collect())?;
-	test_insert((0..=100).collect())?;
-	test_insert((0..=100).collect())?;
-	Ok(())
+    test_insert((0..=100).collect())?;
+    test_insert((0..=100).collect())?;
+    test_insert((0..=100).collect())?;
+    Ok(())
 }
 
 #[test]
 fn medium_insert() -> Result<(), Error> {
-	test_insert((0..=1000).collect())?;
-	test_insert((0..=1000).collect())?;
-	test_insert((0..=1000).collect())?;
-	Ok(())
+    test_insert((0..=1000).collect())?;
+    test_insert((0..=1000).collect())?;
+    test_insert((0..=1000).collect())?;
+    Ok(())
 }
 
 #[test]
 fn large_insert() -> Result<(), Error> {
-	test_insert((0..=50000).collect())?;
-	test_insert((0..=50000).collect())?;
-	test_insert((0..=50000).collect())?;
-	Ok(())
+    test_insert((0..=50000).collect())?;
+    test_insert((0..=50000).collect())?;
+    test_insert((0..=50000).collect())?;
+    Ok(())
 }
 
 fn test_insert(mut values: Vec<u64>) -> Result<(), Error> {
-	let random_file = common::RandomFile::new();
-	let mut rng = rand::thread_rng();
-	{
-		let db = DB::open(&random_file.path)?;
-		{
-			let tx = db.tx(true)?;
-			let b = tx.create_bucket("abc")?;
-			// insert data in a random order
-			values.shuffle(&mut rng);
-			for i in values.iter() {
-				let existing = b.put(i.to_be_bytes(), i.to_string())?;
-				assert!(existing.is_none());
-			}
-			// check before commit
-			check_data(&b, values.len() as u64, 1);
-			assert_eq!(b.next_int(), values.len() as u64);
-			tx.commit()?;
-		}
-		{
-			let tx = db.tx(false)?;
-			let b = tx.get_bucket("abc")?;
-			// check after commit before closing file
-			check_data(&b, values.len() as u64, 1);
-			assert_eq!(b.next_int(), values.len() as u64);
-		}
-	}
-	{
-		let db = DB::open(&random_file.path)?;
-		let tx = db.tx(false)?;
-		let b = tx.get_bucket("abc")?;
-		// check after re-opening file
-		check_data(&b, values.len() as u64, 1);
-		assert_eq!(b.next_int(), values.len() as u64);
-		let missing_key = (values.len() + 1) as u64;
-		assert!(b.get(missing_key.to_be_bytes()).is_none());
-	}
-	let db = DB::open(&random_file.path)?;
-	db.check()
+    let random_file = common::RandomFile::new();
+    let mut rng = rand::thread_rng();
+    {
+        let db = DB::open(&random_file.path)?;
+        {
+            let tx = db.tx(true)?;
+            let b = tx.create_bucket("abc")?;
+            // insert data in a random order
+            values.shuffle(&mut rng);
+            for i in values.iter() {
+                let existing = b.put(i.to_be_bytes(), i.to_string())?;
+                assert!(existing.is_none());
+            }
+            // check before commit
+            check_data(&b, values.len() as u64, 1);
+            assert_eq!(b.next_int(), values.len() as u64);
+            tx.commit()?;
+        }
+        {
+            let tx = db.tx(false)?;
+            let b = tx.get_bucket("abc")?;
+            // check after commit before closing file
+            check_data(&b, values.len() as u64, 1);
+            assert_eq!(b.next_int(), values.len() as u64);
+        }
+    }
+    {
+        let db = DB::open(&random_file.path)?;
+        let tx = db.tx(false)?;
+        let b = tx.get_bucket("abc")?;
+        // check after re-opening file
+        check_data(&b, values.len() as u64, 1);
+        assert_eq!(b.next_int(), values.len() as u64);
+        let missing_key = (values.len() + 1) as u64;
+        assert!(b.get(missing_key.to_be_bytes()).is_none());
+    }
+    let db = DB::open(&random_file.path)?;
+    db.check()
 }
 
 fn check_data(b: &Bucket, len: u64, repeats: usize) {
-	let mut count: u64 = 0;
-	for (i, data) in b.cursor().into_iter().enumerate() {
-		let i = i as u64;
-		count += 1;
-		match &*data {
-			Data::KeyValue(kv) => {
-				assert_eq!(kv.key(), i.to_be_bytes());
-				assert_eq!(kv.value(), i.to_string().repeat(repeats).as_bytes());
-			}
-			_ => panic!("Expected Data::KeyValue"),
-		};
-	}
-	assert_eq!(count, len);
+    let mut count: u64 = 0;
+    for (i, data) in b.cursor().into_iter().enumerate() {
+        let i = i as u64;
+        count += 1;
+        match &*data {
+            Data::KeyValue(kv) => {
+                assert_eq!(kv.key(), i.to_be_bytes());
+                assert_eq!(kv.value(), i.to_string().repeat(repeats).as_bytes());
+            }
+            _ => panic!("Expected Data::KeyValue"),
+        };
+    }
+    assert_eq!(count, len);
 }


### PR DESCRIPTION
There's a lot of changes because I switched to using `rust-analyzer` and it changed all my tabs to spaces, and does not seem configurable 🥲. But besides that, this change adds the `Buckets` and `KVPairs` iterators which yield (as you would expect) Bucket(s) and KVPair(s).

Closes #7 