### PR TITLE
Fix mem alignment

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -119,7 +119,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@1.56.0
+        uses: dtolnay/rust-toolchain@1.60.0
 
       - name: Run tests
         run: cargo test --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,18 +10,18 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
@@ -31,9 +31,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 dependencies = [
  "serde",
 ]
@@ -46,9 +46,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
 dependencies = [
  "libc",
 ]
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jammdb"
@@ -129,24 +129,24 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "memmap2"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
 ]
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1c2c742266c2f1041c914ba65355a83ae8747b05f208319784083583494b4b"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "ppv-lite86"
@@ -184,18 +184,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -254,24 +254,24 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "serde"
-version = "1.0.150"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.150"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.6"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest",
  "keccak",
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -318,9 +318,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ page_size = "0.5"
 fs2 = "0.4"
 sha3 = "0.10"
 bytes = { version = "1", features = ["serde"] }
-bumpalo = "3"
+bumpalo = "3.12.0"
 
 [dev-dependencies]
 rand = "0.8"

--- a/README.md
+++ b/README.md
@@ -9,38 +9,46 @@
 [![License](https://img.shields.io/crates/l/jammdb?style=flat-square)](https://crates.io/crates/jammdb)
 [![Dependency Status](https://deps.rs/repo/github/pjtatlow/jammdb/status.svg?style=flat-square)](https://deps.rs/repo/github/pjtatlow/jammdb)
 
+`jammdb` is an embedded, single-file database that allows you to store key /
+value pairs as bytes.
 
-`jammdb` is an embedded, single-file database that allows you to store key / value pairs as bytes.
+It started life as a Rust port of
+[Ben Johnson's](https://twitter.com/benbjohnson)
+[BoltDB](https://github.com/boltdb/bolt), which was inspired by
+[Howard Chu's](https://twitter.com/hyc_symas) [LMDB](http://symas.com/mdb/), so
+please check out both of these awesome projects!
 
-It started life as a Rust port of [Ben Johnson's](https://twitter.com/benbjohnson) [BoltDB](https://github.com/boltdb/bolt),
-which was inspired by [Howard Chu's](https://twitter.com/hyc_symas) [LMDB](http://symas.com/mdb/),
-so please check out both of these awesome projects!
-
-`jammdb` offers
-[ACID](https://en.wikipedia.org/wiki/ACID) compliance,
+`jammdb` offers [ACID](https://en.wikipedia.org/wiki/ACID) compliance,
 [serializable](https://en.wikipedia.org/wiki/Serializability) and
-[isolated](https://en.wikipedia.org/wiki/Isolation_(database_systems)) transactions,
-with multiple lock-free readers and a single concurrent writer. The data is organized in a
-[single level](https://en.wikipedia.org/wiki/Single-level_store) [B+ tree](https://en.wikipedia.org/wiki/B%2B_tree)
-so random and sequential reads are very fast. The underlying file is [memory mapped](https://en.wikipedia.org/wiki/Memory-mapped_file),
-so reads require no additional memory allocation.
+[isolated](https://en.wikipedia.org/wiki/Isolation_(database_systems))
+transactions, with multiple lock-free readers and a single concurrent writer.
+The data is organized in a
+[single level](https://en.wikipedia.org/wiki/Single-level_store)
+[B+ tree](https://en.wikipedia.org/wiki/B%2B_tree) so random and sequential
+reads are very fast. The underlying file is
+[memory mapped](https://en.wikipedia.org/wiki/Memory-mapped_file), so reads
+require no additional memory allocation.
 
 ## Supported platforms
+
 `jammdb` is continuously cross-compiled and tested on the following platforms:
-  * `x86_64-unknown-linux-gnu` (Linux)
-  * `i686-unknown-linux-gnu`
-  * `x86_64-unknown-linux-musl` (Linux MUSL)
-  * `x86_64-apple-darwin` (OSX)
-  * `x86_64-pc-windows-msvc` (Windows)
-  * `i686-pc-windows-msvc`
-  * `x86_64-pc-windows-gnu`
-  * `i686-pc-windows-gnu`
+
+- `x86_64-unknown-linux-gnu` (Linux)
+- `i686-unknown-linux-gnu`
+- `x86_64-unknown-linux-musl` (Linux MUSL)
+- `x86_64-apple-darwin` (OSX)
+- `x86_64-pc-windows-msvc` (Windows)
+- `i686-pc-windows-msvc`
+- `x86_64-pc-windows-gnu`
+- `i686-pc-windows-gnu`
 
 ## Examples
 
-Here are a couple of simple examples to get you started, but you should check out the docs for more details.
+Here are a couple of simple examples to get you started, but you should check
+out the docs for more details.
 
 ### Simple put and get
+
 ```rust
 use jammdb::{DB, Data, Error};
 
@@ -78,6 +86,7 @@ fn main() -> Result<(), Error> {
 ```
 
 ### Storing structs
+
 ```rust
 use jammdb::{DB, Data, Error};
 use serde::{Deserialize, Serialize};
@@ -129,6 +138,11 @@ fn main() -> Result<(), Error> {
 }
 ```
 
+## MSRV
+
+Currently `1.60`
+
 ## License
 
-Available under both the [Apache License](LICENSE-APACHE) or the [MIT license](LICENSE-MIT).
+Available under both the [Apache License](LICENSE-APACHE) or the
+[MIT license](LICENSE-MIT).

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -2,6 +2,7 @@ use std::{
     cell::{RefCell, RefMut},
     collections::HashMap,
     marker::PhantomData,
+    mem::size_of,
     ops::RangeBounds,
     rc::Rc,
 };
@@ -984,8 +985,12 @@ impl AsRef<[u8]> for BucketMeta {
 
 impl From<&[u8]> for BucketMeta {
     fn from(value: &[u8]) -> Self {
-        let ptr = &value[0] as *const u8;
-        unsafe { *(ptr as *const BucketMeta) }
+        const SIZE: usize = size_of::<BucketMeta>();
+        let mut buf = [0_u8; SIZE];
+        unsafe {
+            std::ptr::copy(value.as_ptr(), buf.as_mut_ptr(), SIZE);
+            *(buf.as_ptr() as *const BucketMeta)
+        }
     }
 }
 

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -986,10 +986,12 @@ impl AsRef<[u8]> for BucketMeta {
 impl From<&[u8]> for BucketMeta {
     fn from(value: &[u8]) -> Self {
         const SIZE: usize = size_of::<BucketMeta>();
-        let mut buf = [0_u8; SIZE];
+        let mut buf = [0_u8; SIZE + 8];
+        let ptr = buf.as_mut_ptr();
         unsafe {
-            std::ptr::copy(value.as_ptr(), buf.as_mut_ptr(), SIZE);
-            *(buf.as_ptr() as *const BucketMeta)
+            let ptr = ptr.add(ptr.align_offset(8));
+            std::ptr::copy(value.as_ptr(), ptr, SIZE);
+            *(ptr as *const BucketMeta)
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,6 +21,8 @@ pub enum Error {
     Sync(&'static str),
     /// Error returned when the DB is found to be in an invalid state
     InvalidDB(String),
+    /// Errors that can occur during allocation
+    Alloc(std::alloc::LayoutError),
 }
 
 impl StdError for Error {}
@@ -36,6 +38,7 @@ impl fmt::Display for Error {
             Error::Io(e) => write!(f, "IO Error: {}", e),
             Error::Sync(s) => write!(f, "Sync Error: {}", s),
             Error::InvalidDB(s) => write!(f, "Invalid DB: {}", s),
+            Error::Alloc(e) => write!(f, "Allocation error: {}", e),
         }
     }
 }
@@ -43,6 +46,12 @@ impl fmt::Display for Error {
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Error {
         Error::Io(err)
+    }
+}
+
+impl From<std::alloc::LayoutError> for Error {
+    fn from(err: std::alloc::LayoutError) -> Error {
+        Error::Alloc(err)
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -361,18 +361,18 @@ impl<'n> Node<'n> {
             return Ok(());
         }
         self.spilled = true;
-        let page = self.allocate(tx_freelist);
+        let page = self.allocate(tx_freelist)?;
         page.write_node(self, self.num_pages)
     }
 
     // Free our old page (if we have one) and get a new page for ourselves.
-    fn allocate<'a>(&'a mut self, tx_freelist: &'a mut TxFreelist) -> &'n mut Page {
+    fn allocate<'a>(&'a mut self, tx_freelist: &'a mut TxFreelist) -> Result<&'n mut Page> {
         self.free_page(tx_freelist);
         let size = self.size();
-        let page = tx_freelist.allocate(size);
+        let page = tx_freelist.allocate(size)?;
         self.page_id = page.id;
         self.num_pages = page.overflow + 1;
-        page
+        Ok(page)
     }
 
     // Give our current page back to the freelist (if we have one)

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -284,7 +284,7 @@ impl<'tx> TxInner<'tx> {
             {
                 freelist.free(self.meta.freelist_page, self.num_freelist_pages);
                 let freelist_size = freelist.inner.size();
-                let page = freelist.allocate(freelist_size);
+                let page = freelist.allocate(freelist_size)?;
                 self.meta.freelist_page = page.id;
                 let free_page_ids = freelist.inner.pages();
                 page.page_type = Page::TYPE_FREELIST;
@@ -583,29 +583,29 @@ mod tests {
             assert_eq!(freelist.inner.pages(), vec![2, 3, 4, 5, 6]);
             // allocate some pages from the freelist
             assert_eq!(freelist.meta.num_pages, 10);
-            let page = freelist.allocate(size_of::<Page>() as u64);
+            let page = freelist.allocate(size_of::<Page>() as u64)?;
             assert!(page.id == 2);
             assert!(page.overflow == 0);
 
-            let page = freelist.allocate(size_of::<Page>() as u64);
+            let page = freelist.allocate(size_of::<Page>() as u64)?;
             assert!(page.id == 3);
             assert!(page.overflow == 0);
 
-            let page = freelist.allocate(size_of::<Page>() as u64);
+            let page = freelist.allocate(size_of::<Page>() as u64)?;
             assert!(page.id == 4);
             assert!(page.overflow == 0);
 
-            let page = freelist.allocate(size_of::<Page>() as u64);
+            let page = freelist.allocate(size_of::<Page>() as u64)?;
             assert!(page.id == 5);
             assert!(page.overflow == 0);
 
-            let page = freelist.allocate(size_of::<Page>() as u64);
+            let page = freelist.allocate(size_of::<Page>() as u64)?;
             assert!(page.id == 6);
             assert!(page.overflow == 0);
 
             // freelist should be empty so make sure the page is new
             assert_eq!(freelist.meta.num_pages, 10);
-            let page = freelist.allocate(size_of::<Page>() as u64);
+            let page = freelist.allocate(size_of::<Page>() as u64)?;
             assert!(page.id == 10);
             assert!(page.overflow == 0);
             assert_eq!(freelist.meta.num_pages, 11);


### PR DESCRIPTION
This PR resolves the issues that were surfaced by the changes in rust 1.70, where misaligned pointer dereferences now cause panics. The issues were two-fold:

1. When allocating memory using `bumpalo` we weren't specifying the alignment, so adding the alignment to the layout fixed that.
2. When getting a `BucketMeta` from the memory mapped data, it's likely that data won't be aligned properly. The fix for this one is to copy the data (16 bytes) to a buffer and then cast it to a `*BucketMeta`, which we then dereference and return.

Fixes #26